### PR TITLE
handleIgnore function - variable type error

### DIFF
--- a/magmi/engines/magmi_productimportengine.php
+++ b/magmi/engines/magmi_productimportengine.php
@@ -1250,7 +1250,7 @@ class Magmi_ProductImportEngine extends Magmi_Engine
 		//filter __MAGMI_IGNORE__ COLUMNS
 		foreach($item as $k=>$v)
 		{
-			if($v=="__MAGMI_IGNORE__")
+			if($v==="__MAGMI_IGNORE__")
 			{
 				unset($item[$k]);
 			}


### PR DESCRIPTION
If (int)0 is used as a variable value in the $item array, the ignore function will unset it from the array.

Added a type check into the IF to remedy.
