### PR TITLE
[WIP] Restrict autolink to current file

### DIFF
--- a/magmi/plugins/base/itemprocessors/configurables/magmi_configurableprocessor.php
+++ b/magmi/plugins/base/itemprocessors/configurables/magmi_configurableprocessor.php
@@ -83,9 +83,15 @@ public function getConfigurableOptsFromAsId($asid)
 	}
 	
 	
-	public function autoLink($pid)
+	public function autoLink($pid, $skulist=array())
 	{
-		$this->dolink($pid,"LIKE CONCAT(cpec.sku,'%')");
+		if($this->getParam("CFGR:restrictskus")==1){
+			if(!empty($skulist)){
+				$this->dolink($pid,"LIKE CONCAT(cpec.sku,'%') AND cpes.sku IN (".$this->arr2values($skulist).")", $skulist);
+			}
+		}else{
+			$this->dolink($pid,"LIKE CONCAT(cpec.sku,'%')");
+		}
 	}
 	
 	public function updSimpleVisibility($pid)
@@ -172,7 +178,7 @@ public function getConfigurableOptsFromAsId($asid)
 		//if item is not configurable, nothing to do
 		if($item["type"]!=="configurable")
 		{
-			if($this->getParam("CFGR:simplesbeforeconf")==1)
+			if($this->getParam("CFGR:simplesbeforeconf")==1 || $this->getParam("CFGR:restrictskus")==1))
 			{
 				$this->_currentsimples[]=$item["sku"];
 			}
@@ -319,7 +325,7 @@ public function getConfigurableOptsFromAsId($asid)
 				break;
 			case "auto":
 				//destroy old associations
-				$this->autoLink($pid);
+				$this->autoLink($pid,$this->_currentsimples);	
 				$this->updSimpleVisibility($pid);
 				break;
 			case "cursimples":
@@ -360,7 +366,7 @@ public function getConfigurableOptsFromAsId($asid)
 	
 	public function getPluginParamNames()
 	{
-		return array("CFGR:simplesbeforeconf","CFGR:updsimplevis","CFGR:nolink");
+		return array("CFGR:simplesbeforeconf","CFGR:updsimplevis","CFGR:nolink","CFGR:restrictskus");
 	}
 	
 	static public function getCategory()

--- a/magmi/plugins/base/itemprocessors/configurables/magmi_configurableprocessor.php
+++ b/magmi/plugins/base/itemprocessors/configurables/magmi_configurableprocessor.php
@@ -178,7 +178,7 @@ public function getConfigurableOptsFromAsId($asid)
 		//if item is not configurable, nothing to do
 		if($item["type"]!=="configurable")
 		{
-			if($this->getParam("CFGR:simplesbeforeconf")==1 || $this->getParam("CFGR:restrictskus")==1))
+			if($this->getParam("CFGR:simplesbeforeconf")==1 || $this->getParam("CFGR:restrictskus")==1)
 			{
 				$this->_currentsimples[]=$item["sku"];
 			}

--- a/magmi/plugins/base/itemprocessors/configurables/options_panel.php
+++ b/magmi/plugins/base/itemprocessors/configurables/options_panel.php
@@ -12,6 +12,15 @@ This plugins handles configurable import
 	</li>
 </ul>
 <ul class="formline">
+	<li class="label" style="width:360px">Only autolink simples from current import.</li>
+	<li class="value">
+	<select name="CFGR:restrictskus">
+	<option value="0" <?php if ($this->getParam("CFGR:restrictskus",0)==0){?>selected="selected"<?php }?>>No</option>
+	<option value="1" <?php if ($this->getParam("CFGR:restrictskus",0)==1){?>selected="selected"<?php }?>>Yes</option>
+	</select>
+	</li>
+</ul>
+<ul class="formline">
 	<li class="label" style="width:360px">auto match simples skus before configurable</li>
 	<li class="value"><select name="CFGR:simplesbeforeconf">
 	<option value="0" <?php if ($this->getParam("CFGR:simplesbeforeconf")==0){?>selected="selected"<?php }?>>No</option>


### PR DESCRIPTION
I have a webshop with many products, and some have short sku's. When importing via Magmi, I use automatching of sku's with the same start.
Is it possible to match the sku's only in the current file?
I did some tweaks, to also keep track of the skuList for the 'auto' matchmode, and do a link like this, instead of autoLink.

TODO:
- [ ] Test it
- [ ] Update docs

This hasn't been thouroughly tested, but what do you think of the idea/implementation?