### PR TITLE
Update dbhelper.class.php: filterkvarr()

### DIFF
--- a/magmi/inc/dbhelper.class.php
+++ b/magmi/inc/dbhelper.class.php
@@ -496,7 +496,7 @@ class DBHelper
         $out = array();
         foreach ($keys as $k)
         {
-            $out[$k] = (isset($kvarr[$k]) && $kvarr[$k] != '__NULL__') ? $kvarr[$k] : null;
+            $out[$k] = (isset($kvarr[$k]) && $kvarr[$k] !== '__NULL__') ? $kvarr[$k] : null;
         }
         return $out;
     }


### PR DESCRIPTION
This problem prevented me from performing a stock update using a fresh install of Magmi 0.7.19a on a fresh install of Magento CE 1.9.0.1. I created two simple products in Magento and tried to update their stock information them using Magmi. I created a two-column CSV ("sku" and "qty") and attempted to import it. I got the following errors:

1 SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'use_config_manage_stock' cannot be null -
2 SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'use_config_manage_stock' cannot be null - ERROR ON RECORD #1
3 SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'use_config_manage_stock' cannot be null -
4 SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'use_config_manage_stock' cannot be null - ERROR ON RECORD #2

More details on this error are here: https://sourceforge.net/p/magmi/discussion/1228365/thread/8e722889/

I tracked the problem to filterkvarr(). If the $kvarr has values which are numerical 0's, the function changes their values to null. This is because var_dump(0 == '**NULL**'); // 0 == 0 -> true. However, var_dump(0 === '**NULL**'); // 0 !== '**NULL**' -> false. So I suggest this change. (See PHP's documentation on this: http://us1.php.net/operators.comparison).
