### PR TITLE
Update magmi_valueparser.php: parseValue()

### DIFF
--- a/magmi/inc/magmi_valueparser.php
+++ b/magmi/inc/magmi_valueparser.php
@@ -27,13 +27,7 @@ class Magmi_ValueParser
                     {
                         if (in_array($match, $ik))
                         {
-                            if (strpos($dictarray[$key][$match], '"') !== FALSE)
-                            {
-                                $rep = $renc . preg_replace('/"/', '\\"', $dictarray[$key][$match]) . $renc;
-                            }
-                            else {
-                                $rep = $renc . $dictarray[$key][$match] . $renc;
-                            }
+                            $rep = $renc . str_replace('"', '\\"', $dictarray[$key][$match]) . $renc;
                         }
                         else
                         {


### PR DESCRIPTION
I rely on the Value Replacer plugin to modify portions of my CSV input files. I found that it did not work on column values that contained double quotes. The Value Replacer's wiki page indicates that working with double quotes is a problem, but it's not clear that values in the CSV can also not have double quotes in them. This change will allow double quotes to be present in values worked on by the Value Replacer plugin.
