### PR TITLE
Add check for non-empty sku list on grouped product import

### DIFF
--- a/magmi/plugins/base/itemprocessors/grouped/alpine_groupedprocessor.php
+++ b/magmi/plugins/base/itemprocessors/grouped/alpine_groupedprocessor.php
@@ -215,7 +215,9 @@ class Magmi_GroupedItemProcessor extends Magmi_ItemProcessor
      */
     public function fixedLink($pid, $skulist, $gr = true)
     {
-        $this->dolink($pid, "IN (" . $this->arr2values($skulist) . ")", $gr, $skulist);
+        if(!empty($skulist)) {
+            $this->dolink($pid, "IN (" . $this->arr2values($skulist) . ")", $gr, $skulist);
+        }
     }
 
     /**


### PR DESCRIPTION
Currently it is not possible to import grouped products without any associated simple products. It will result in a database error since the plugin tries to autoLink simple products which may or may not succeed (depending on the skus).

It is necessary to add a check in fixedLink method if the $skulist is non-empty. Else there will always be a database error when working with an empty list, resulting in the failure of the import of that grouped product.
