### PR TITLE
Do not force url_key if column exists for Magento ver > 1.7.x

### DIFF
--- a/magmi/plugins/inc/magmi_defaultattributehandler.php
+++ b/magmi/plugins/inc/magmi_defaultattributehandler.php
@@ -87,7 +87,7 @@ class Magmi_DefaultAttributeItemProcessor extends Magmi_ItemProcessor
             $this->initializeBaseCols($item);
             $this->initializeBaseAttrs($item);
             //force url key for new items for magento > 1.7.x
-            if($this->getMagentoVersion()>"1.7.x")
+            if($this->getMagentoVersion()>"1.7.x" && empty($item['url_key']))
             {
                $item["url_key"]=Slugger::slug($item["name"]);
             } 


### PR DESCRIPTION
Make url_key override-able 
