### PR TITLE
(ValueParser) Allow for multiline values in CSV

### DIFF
--- a/magmi/inc/magmi_valueparser.php
+++ b/magmi/inc/magmi_valueparser.php
@@ -41,7 +41,7 @@ class Magmi_ValueParser
         }
         
         // replacing expr values
-        while (preg_match("|\{\{\s*(.*?)\s*\}\}|", $pvalue, $matches))
+        while (preg_match("|\{\{\s*(.*?)\s*\}\}|s", $pvalue, $matches))
         {
             foreach ($matches as $match)
             {
@@ -53,14 +53,14 @@ class Magmi_ValueParser
                     $rep = eval("return ($code);");
                     // escape potential "{{xxx}}" values in interpreted target
                     // so that they won't be reparsed in next round
-                    $rep = preg_replace("|\{\{\s*(.*?)\s*\}\}|", "____$1____", $rep);
+                    $rep = preg_replace("|\{\{\s*(.*?)\s*\}\}|s", "____$1____", $rep);
                     $pvalue = str_replace($matches[0], $rep, $pvalue);
                 }
             }
         }
         
         // unescape matches
-        $pvalue = preg_replace("|____(.*?)____|", '{{$1}}', $pvalue);
+        $pvalue = preg_replace("|____(.*?)____|s", '{{$1}}', $pvalue);
         // single replaced values
         $pvalue = str_replace($renc, '', $pvalue);
         return "" . $pvalue;


### PR DESCRIPTION
Some values in my CSV files contained contained linefeed or carriage return characters (within a field, not just at the end of lines). When trying to work with these fields with the ValueReplacer plugin, they did not get replaced. I fixed this with the changes on this commit by allowing multiline wildcard (.) matches in 3 preg_ matching and replacing functions (by adding the 's' after the final pattern delimiter).
