### PR TITLE
[FIX] Mass Select Option Remapper PDO exception error

### DIFF
--- a/magmi/plugins/utilities/massopt_remap/mass_selectremap.php
+++ b/magmi/plugins/utilities/massopt_remap/mass_selectremap.php
@@ -54,7 +54,7 @@ class MassOptionRemapper extends Magmi_UtilityPlugin
         {
             $csmode = "COLLATE utf8_bin";
         }
-        if (!preg_match("/(.*)/", $from, $matches))
+        if (!preg_match("/re::(.*)/", $from, $matches))
         {
             $where = "(SELECT eao.option_id FROM 
 			$eao as eao 


### PR DESCRIPTION
Fixed "SQLSTATE[HY093]: Invalid parameter number: number of bound variables does not match number of tokens" exception in the Mass Select Option Remapper tool.
