### PR TITLE
Adding a .htaccess file to 404 all requests that don't go to web/ 

### DIFF
--- a/magmi/.htaccess
+++ b/magmi/.htaccess
@@ -1,0 +1,2 @@
+# 404 all requests that don't go to the web/ subdirectory
+RedirectMatch 404 ^((?!/web/).)*$


### PR DESCRIPTION
Currently it seems that there is no security preventing web requests from reaching sensitive Magmi files, including conf/magmi.ini (which stores database host, username, and password!). This simple .htaccess file blocks web access to all directories except the web/ directory. It only works for Apache, but I think having this is an improvement over having nothing.
