### PR TITLE
adding ability to use magento's local xml file as a database connector

### DIFF
--- a/magmi/inc/dbhelper.class.php
+++ b/magmi/inc/dbhelper.class.php
@@ -47,13 +47,13 @@ class DBHelper
     {
         // intialize connection with PDO
         // fix by Mr Lei for UTF8 special chars
-        if ($conntype == "net")
+        if ($conntype == "socket")
         {
-            $pdostr = "mysql:host=$host;port=$port;dbname=$dbname;charset=utf8";
+            $pdostr = "mysql:unix_socket=$socket;dbname=$dbname;charset=utf8";
         }
         else
         {
-            $pdostr = "mysql:unix_socket=$socket;dbname=$dbname;charset=utf8";
+        	$pdostr = "mysql:host=$host;port=$port;dbname=$dbname;charset=utf8";
         }
         
         $this->_db = new PDO($pdostr, $user, $pass, array(PDO::MYSQL_ATTR_INIT_COMMAND=>"SET NAMES utf8"));

--- a/magmi/inc/magmi_engine.php
+++ b/magmi/inc/magmi_engine.php
@@ -515,17 +515,29 @@ abstract class Magmi_Engine extends DbHelper
      */
     public function connectToMagento()
     {
-        // et database infos from properties
+    	// et database infos from properties
         if (!$this->_connected)
         {
-            $host = $this->getProp("DATABASE", "host", "localhost");
-            $dbname = $this->getProp("DATABASE", "dbname", "magento");
-            $user = $this->getProp("DATABASE", "user");
-            $pass = $this->getProp("DATABASE", "password");
-            $debug = $this->getProp("DATABASE", "debug");
+        	
             $conn = $this->getProp("DATABASE", "connectivity", "net");
-            $port = $this->getProp("DATABASE", "port", "3306");
+            $debug = $this->getProp("DATABASE", "debug");
             $socket = $this->getProp("DATABASE", "unix_socket");
+            if ($conn == 'localxml') {
+            	$baseDir = $this->getProp('MAGENTO', 'basedir');
+            	$xml = new SimpleXMLElement(file_get_contents($baseDir.'app/etc/local.xml'));
+            	$default_setup = $xml->global->resources->{$this->getProp('DATABASE', 'resource', 'default_setup')}->connection;
+            	$host = $default_setup->host;
+            	$dbname = $default_setup->dbname;
+            	$user = $default_setup->username;
+            	$pass = $default_setup->password;
+            	$port = $default_setup->port;
+            } else {
+            	$host = $this->getProp("DATABASE", "host", "localhost");
+            	$dbname = $this->getProp("DATABASE", "dbname", "magento");
+            	$user = $this->getProp("DATABASE", "user");
+            	$pass = $this->getProp("DATABASE", "password");
+            	$port = $this->getProp("DATABASE", "port", "3306");
+            }
             $this->initDb($host, $dbname, $user, $pass, $port, $socket, $conn, $debug);
             // suggested by pastanislas
             $this->_db->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, true);

--- a/magmi/web/ajax_readlocalxml.php
+++ b/magmi/web/ajax_readlocalxml.php
@@ -1,0 +1,13 @@
+<?php 
+require_once ("../inc/magmi_config.php");
+$conf = Magmi_Config::getInstance();
+$conf->load();
+
+$selected = $conf->get('DATABASE', 'resource');
+$magentoConfig = new SimpleXMLElement(file_get_contents($conf->get('MAGENTO', 'basedir').'app/etc/local.xml'));
+foreach ($magentoConfig->global->resources->children() as $resource) {
+	$name = $resource->getName();
+	if ($name != 'db') {
+		echo '<option value="'.$name.'" '.($selected == $name ? 'selected' : '').'>'.$name.'</option>';
+	}
+}

--- a/magmi/web/magmi_config_setup.php
+++ b/magmi/web/magmi_config_setup.php
@@ -158,21 +158,21 @@ $cansock = !($dmysqlsock === false);
 			<h3>Database</h3>
 	
 	<?php $curconn=$conf->get("DATABASE","connectivity","net");?>
-	<ul class="formline">
+			<ul class="formline">
 				<li class="label">Connectivity</li>
-				<li class="value"><select name="DATABASE:connectivity"
-					id="DATABASE:connectivity">
-						<option value="net" <?php if($curconn=="net"){?>
-							selected="selected" <?php }?>>Using host/port</option>
-			<?php if($cansock){?>
-			<option value="socket" <?php if($curconn=="socket"){?>
-							selected="selected" <?php }?>>Using local socket</option>
-			<?php }?>
-		</select></li>
+				<li class="value"><select name="DATABASE:connectivity" id="DATABASE:connectivity">
+					<option value="net" <?php if($curconn=="net") { ?>
+						selected="selected" <?php } ?>>Using host/port</option>
+					<?php if($cansock) { ?>
+					<option value="socket" <?php if($curconn=="socket") { ?>
+						selected="selected" <?php } ?>>Using local socket</option>
+					<?php }?>
+					<option value="localxml" <?php echo $curconn == "localxml" ? 'selected="selected"' : '' ?>>Using magento.xml</option>
+				</select></li>
 			</ul>
 
 			<div id="connectivity:net" class="connectivity"
-				<?php if($curconn!="net"){?> style="display: none" <?php }?>>
+				<?php if($curconn != "net"){?> style="display: none" <?php }?>>
 				<ul class="formline">
 					<li class="label">Host:</li>
 					<li class="value"><input type="text" name="DATABASE:host"
@@ -184,47 +184,56 @@ $cansock = !($dmysqlsock === false);
 						value="<?php echo $conf->get("DATABASE","port","3306")?>"></input></li>
 				</ul>
 			</div>
-	<?php if($cansock){?>
-	<div id="connectivity:socket" class="connectivity"
-				<?php if($curconn!="socket"){?> style="display: none" <?php  }?>>
+			<div id="connectivity:localxml" class="connectivity" <?php echo $curconn != 'localxml' ? 'style="display: none;"' : '' ?>>
 				<ul class="formline">
-					<li class="label">Unix Socket:</li>
-		
-		<?php
-    $mysqlsock = $conf->get("DATABASE", "unix_socket", $dmysqlsock);
-    if (!file_exists($mysqlsock))
-    {
-        $mysqlsock = $dmysqlsock;
-    }
-    ?>
-		<li class="value"><input type="text" name="DATABASE:unix_socket"
-						value="<?php echo $mysqlsock?>"></input></li>
+					<li class="label">Resource:</li>
+					<li class="value"><select id="select_localxml_resources" name="DATABASE:resource">
+						<option value="<?php echo $conf->get('DATABASE', 'resource', 'default_setup'); ?>"><?php echo $conf->get('DATABASE', 'resource', 'default_setup'); ?></option>
+					</select>
 				</ul>
 			</div>
-	<?php }?>	
-	<hr />
-
-			<ul class="formline">
-				<li class="label">DB Name:</li>
-				<li class="value"><input type="text" name="DATABASE:dbname"
-					value="<?php echo $conf->get("DATABASE","dbname")?>"></input></li>
-			</ul>
-
-			<ul class="formline">
-				<li class="label">Username:</li>
-				<li class="value"><input type="text" name="DATABASE:user"
-					value="<?php echo $conf->get("DATABASE","user")?>"></input></li>
-			</ul>
-			<ul class="formline">
-				<li class="label">Password:</li>
-				<li class="value"><input type="password" name="DATABASE:password"
-					value="<?php echo $conf->get("DATABASE","password")?>"></input></li>
-			</ul>
-			<ul class="formline">
-				<li class="label">Table prefix:</li>
-				<li class="value"><input type="text" name="DATABASE:table_prefix"
-					value="<?php echo $conf->get("DATABASE","table_prefix")?>"></input></li>
-			</ul>
+			<?php if($cansock){?>
+				<div id="connectivity:socket" class="connectivity"
+							<?php if($curconn != "socket"){?> style="display: none" <?php  }?>>
+							<ul class="formline">
+								<li class="label">Unix Socket:</li>
+					
+					<?php
+					    $mysqlsock = $conf->get("DATABASE", "unix_socket", $dmysqlsock);
+					    if (!file_exists($mysqlsock))
+					    {
+					        $mysqlsock = $dmysqlsock;
+					    }
+				    ?>
+					<li class="value"><input type="text" name="DATABASE:unix_socket"
+									value="<?php echo $mysqlsock?>"></input></li>
+					</ul>
+			</div>
+			<?php }?>	
+			<div id="connectivity_extra" <?php echo $curconn == 'localxml' ? 'style="display: none;"' : ''; ?>>
+				<hr />
+				<ul class="formline">
+					<li class="label">DB Name:</li>
+					<li class="value"><input type="text" name="DATABASE:dbname"
+						value="<?php echo $conf->get("DATABASE","dbname")?>"></input></li>
+				</ul>
+	
+				<ul class="formline">
+					<li class="label">Username:</li>
+					<li class="value"><input type="text" name="DATABASE:user"
+						value="<?php echo $conf->get("DATABASE","user")?>"></input></li>
+				</ul>
+				<ul class="formline">
+					<li class="label">Password:</li>
+					<li class="value"><input type="password" name="DATABASE:password"
+						value="<?php echo $conf->get("DATABASE","password")?>"></input></li>
+				</ul>
+				<ul class="formline">
+					<li class="label">Table prefix:</li>
+					<li class="value"><input type="text" name="DATABASE:table_prefix"
+						value="<?php echo $conf->get("DATABASE","table_prefix")?>"></input></li>
+				</ul>
+			</div>
 		</div>
 		<div class="grid_4 col">
 			<h3>Magento</h3>
@@ -243,7 +252,6 @@ $cansock = !($dmysqlsock === false);
 				<li class="value"><input type="text" name="MAGENTO:basedir"
 					value="<?php echo $conf->get("MAGENTO","basedir")?>"></input></li>
 			</ul>
-
 		</div>
 		<div class="grid_4 col omega">
 			<h3>Global</h3>
@@ -321,6 +329,22 @@ $('DATABASE:connectivity').observe('change',function(ev)
 							el.hide();
 						}
 					});
-			
+			if ($F('DATABASE:connectivity') != 'localxml') {
+				$('connectivity_extra').show();
+			} else {
+				$('connectivity_extra').hide();
+				new Ajax.Updater('select_localxml_resources',
+					'ajax_readlocalxml.php', {
+						parameters: $('commonconf_form').serialize('true')
+					}
+				);
+			}
 		});
+if ($('DATABASE:connectivity').value == 'localxml') {
+	new Ajax.Updater('select_localxml_resources',
+		'ajax_readlocalxml.php', {
+			parameters: $('commonconf_form').serialize('true')
+		}
+	);
+}
 </script>


### PR DESCRIPTION
I updated the connector options to allow using magento's localxml file. If selected, it will automatically read it and populate the resources dropdown with the available options from localxml, and magmi will then use those database credentials instead of having to specify them within the global config.
