### PR TITLE
Fixing bug causing empty categories to be imported

### DIFF
--- a/magmi/engines/magmi_productimportengine.php
+++ b/magmi/engines/magmi_productimportengine.php
@@ -1271,6 +1271,10 @@ class Magmi_ProductImportEngine extends Magmi_Engine
             // ow we have verified ids
             foreach ($cdata as $catid => $catpos)
             {
+            	if(empty($catid)) {
+            	    continue;
+            	}
+            	
                 $inserts[] = "(?,?,?)";
                 $data[] = $catid;
                 $data[] = $pid;


### PR DESCRIPTION
I've encountered a bug (at least on linux based systems) that caused a SQL exception when trying to import non-existent category ids. This simple fix checks if there actually is a category id present in the array before adding it to the SQL query.
