### PR TITLE
configurables: dynamic simples sku separator

### DIFF
--- a/magmi/plugins/base/itemprocessors/configurables/magmi_configurableprocessor.php
+++ b/magmi/plugins/base/itemprocessors/configurables/magmi_configurableprocessor.php
@@ -12,7 +12,7 @@ class Magmi_ConfigurableItemProcessor extends Magmi_ItemProcessor
     /* Plugin info declaration */
     public function getPluginInfo()
     {
-        return array("name"=>"Configurable Item processor","author"=>"Dweeves","version"=>"1.3.7a",
+        return array("name"=>"Configurable Item processor","author"=>"Dweeves","version"=>"1.3.8a",
             "url"=>$this->pluginDocUrl("Configurable_Item_processor"));
     }
 
@@ -340,7 +340,7 @@ class Magmi_ConfigurableItemProcessor extends Magmi_ItemProcessor
                 
                 break;
             case "fixed":
-                $sskus = explode(",", $item["simples_skus"]);
+                $sskus = explode($this->getParam("CFGR:simplesskuseparator", ','), $item["simples_skus"]);
                 trimarray($sskus);
                 $this->fixedLink($pid, $sskus);
                 $this->updSimpleVisibility($pid);
@@ -371,7 +371,7 @@ class Magmi_ConfigurableItemProcessor extends Magmi_ItemProcessor
 
     public function getPluginParamNames()
     {
-        return array("CFGR:simplesbeforeconf","CFGR:updsimplevis","CFGR:nolink");
+        return array("CFGR:simplesbeforeconf","CFGR:updsimplevis","CFGR:nolink","CFGR:simplesskuseparator");
     }
 
     static public function getCategory()

--- a/magmi/plugins/base/itemprocessors/configurables/options_panel.php
+++ b/magmi/plugins/base/itemprocessors/configurables/options_panel.php
@@ -24,6 +24,12 @@
 	</select></li>
 </ul>
 <ul class="formline">
+	<li class="label">Simples Sku Separator</li>
+	<li class="value">
+		<input type="text" name="CFGR:simplesskuseparator" value="<?php echo $this->getParam('CFGR:simplesskuseparator', ',') ?>" />
+    </li>
+</ul>
+<ul class="formline">
 	<li class="label">Force simples visibility</li>
 	<li class="value">
 <?php $v=$this->getParam("CFGR:updsimplevis",0)?>


### PR DESCRIPTION
I added the ability to configure the simples_skus separator for configurable products. Before this fix I had to hack this plugin when importing products with a comma in their skus.
