### PR TITLE
Use version_compare to check magento version

### DIFF
--- a/magmi/engines/magmi_productimportengine.php
+++ b/magmi/engines/magmi_productimportengine.php
@@ -374,7 +374,7 @@ class Magmi_ProductImportEngine extends Magmi_Engine
             $qcolstr = $this->arr2values($toscan);
             
             $tname = $this->tablename("eav_attribute");
-            if ($this->getMagentoVersion() != "1.3.x")
+            if ($this->checkMagentoVersion("1.3.x", "!="))
             {
                 $extra = $this->tablename("catalog_eav_attribute");
                 // SQL for selecting attribute properties for all wanted attributes

--- a/magmi/inc/magmi_engine.php
+++ b/magmi/inc/magmi_engine.php
@@ -83,6 +83,14 @@ abstract class Magmi_Engine extends DbHelper
     {
         return $this->_conf->get("MAGENTO", "version");
     }
+    
+    /**
+     * checks the magento version
+     */
+    public function checkMagentoVersion($version, $operator)
+    {
+        return version_compare($this->getMagentoVersion(), $version, $operator);
+    }
 
     /**
      * Plugin loop callback registration

--- a/magmi/plugins/base/itemprocessors/configurables/magmi_configurableprocessor.php
+++ b/magmi/plugins/base/itemprocessors/configurables/magmi_configurableprocessor.php
@@ -35,7 +35,7 @@ class Magmi_ConfigurableItemProcessor extends Magmi_ItemProcessor
 		JOIN $eas as eas ON eas.entity_type_id=eet.entity_type_id AND eas.attribute_set_id=?
 		JOIN $eea as eea ON eea.attribute_id=ea.attribute_id";
             $cond = "ea.is_user_defined=1";
-            if ($this->getMagentoVersion() != "1.3.x")
+            if ($this->checkMagentoVersion("1.3.x", "!="))
             {
                 $cea = $this->tablename("catalog_eav_attribute");
                 $sql .= " JOIN $cea as cea ON cea.attribute_id=ea.attribute_id AND cea.is_global=1 AND cea.is_configurable=1";

--- a/magmi/plugins/inc/magmi_defaultattributehandler.php
+++ b/magmi/plugins/inc/magmi_defaultattributehandler.php
@@ -86,7 +86,7 @@ class Magmi_DefaultAttributeItemProcessor extends Magmi_ItemProcessor
             $this->initializeBaseCols($item);
             $this->initializeBaseAttrs($item);
             //force url key for new items for magento > 1.7.x
-            if($this->getMagentoVersion()>"1.7.x" && empty($item['url_key']))
+            if($this->checkMagentoVersion("1.7.x", ">") && empty($item['url_key']))
             {
                $item["url_key"]=Slugger::slug($item["name"]);
             } 

--- a/magmi/plugins/utilities/clearproductsandcategories/clearproductsandcategories.php
+++ b/magmi/plugins/utilities/clearproductsandcategories/clearproductsandcategories.php
@@ -39,7 +39,7 @@ class ClearProductandcategoryUtility extends Magmi_UtilityPlugin
 
             "review","review_detail","review_entity_summary","review_store");
         
-        if ($this->getMagentoVersion() >= "1.7.")
+        if ($this->checkMagentoVersion("1.7.x", ">="))
         {
             $tables[] = "report_viewed_product_aggregated_daily";
             $tables[] = "report_viewed_product_aggregated_monthly";


### PR DESCRIPTION
Using strings to compare versions isn't very reliable. Especially because we are currently at '1.9.x'. If you string compare that with '1.10.x', php thinks that 1.9.x > 1.10.x.

PHP has a built-in [version_compare function](http://php.net/manual/en/function.version-compare.php) that accounts for this. This PR adds a method to check the Magento version against a given version + operator. 