### PR TITLE
Fix local.xml path

### DIFF
--- a/magmi/inc/magmi_engine.php
+++ b/magmi/inc/magmi_engine.php
@@ -522,7 +522,12 @@ abstract class Magmi_Engine extends DbHelper
             $socket = $this->getProp("DATABASE", "unix_socket");
             if ($conn == 'localxml') {
             	$baseDir = $this->getProp('MAGENTO', 'basedir');
-            	$xml = new SimpleXMLElement(file_get_contents($baseDir.'app/etc/local.xml'));
+            	$xmlPath = $baseDir.'/app/etc/local.xml';
+                if (!file_exists($xmlPath))
+                {
+                    throw new Exception("Cannot load xml from path '$xmlPath'");
+                }
+            	$xml = new SimpleXMLElement(file_get_contents($xmlPath));
             	$default_setup = $xml->global->resources->{$this->getProp('DATABASE', 'resource', 'default_setup')}->connection;
             	$host = $default_setup->host;
             	$dbname = $default_setup->dbname;


### PR DESCRIPTION
The default dir is '../..', which will lead to an incorrect path. Throw a more helpful exception when the path is not found.