### PR TITLE
Get all stores for admin scope

### DIFF
--- a/magmi/engines/magmi_productimportengine.php
+++ b/magmi/engines/magmi_productimportengine.php
@@ -168,11 +168,18 @@ class Magmi_ProductImportEngine extends Magmi_Engine
         if (!isset($this->_sid_sscope[$scodes]))
         {
             $this->_sid_sscope[$scodes] = array();
-            $scarr = csl2arr($scodes);
-            $qcolstr = $this->arr2values($scarr);
             $cs = $this->tablename("core_store");
-            $sql = "SELECT csmain.store_id from $cs as csmain WHERE csmain.code IN ($qcolstr)";
-            $sidrows = $this->selectAll($sql, $scarr);
+            
+            if ($scodes == 'admin') {
+                $sql = "SELECT csmain.store_id from $cs as csmain";
+                $sidrows = $this->selectAll($sql, $scarr);
+            } else {
+                $scarr = csl2arr($scodes);
+                $qcolstr = $this->arr2values($scarr);
+                $sql = "SELECT csmain.store_id from $cs as csmain WHERE csmain.code IN ($qcolstr)";
+                $sidrows = $this->selectAll($sql, $scarr);
+            }
+            
             foreach ($sidrows as $sidrow)
             {
                 $this->_sid_sscope[$scodes][] = $sidrow["store_id"];


### PR DESCRIPTION
When the scope is admin, shouldn't all stores be selected?

In my case, I had a 'price' attribute, which had the same value for multiple stores. But when updating, only the admin value was updated, so the actual storeview values where kept. I did have the prices configured as global..

Or should I have configured something else differently?