### PR TITLE
Fix table name on tax_class, made group name not case sensitive

### DIFF
--- a/magmi/plugins/extra/itemprocessors/groupprice/grouppriceprocessor.php
+++ b/magmi/plugins/extra/itemprocessors/groupprice/grouppriceprocessor.php
@@ -102,8 +102,8 @@ class GrouppriceProcessor extends Magmi_ItemProcessor
             {
             	$groupname=$matches[1];
                 $sql = 'SELECT customer_group_id FROM ' . $this->tablename("customer_group") .
-                     ' WHERE customer_group_code = ?';
-                if ($id = $this->selectone($sql, $groupname, "customer_group_id"))
+                     ' WHERE UPPER(customer_group_code) = ?';
+                if ($id = $this->selectone($sql, strtoupper($groupname), "customer_group_id"))
                 {
                     $this->_groups[$col] = array('name'=>$groupname,'id'=>$id);
                 }
@@ -127,7 +127,7 @@ class GrouppriceProcessor extends Magmi_ItemProcessor
         $sql = 'SELECT value FROM ' . $this->tablename('core_config_data') . ' WHERE path = ?';
         $this->_priceScope = intval($this->selectone($sql, array('catalog/price/scope'), 'value'));
         /* Getting customer tax class */
-        $sql="SELECT class_id FROM tax_class WHERE class_type='CUSTOMER'";
+        $sql="SELECT class_id FROM " . $this->tablename('tax_class') . " WHERE class_type='CUSTOMER'";
         $this->_tax_class_id=$this->selectone($sql,null,'class_id');
         
     }


### PR DESCRIPTION
I noticed a select on the tax_class breaking, also the group name was case sensitive so just added some UPPER() and strtoupper() for cleanliness