### PR TITLE
Fixing hard coded table name

### DIFF
--- a/magmi/plugins/extra/itemprocessors/downloadable/downloadableprocessor.php
+++ b/magmi/plugins/extra/itemprocessors/downloadable/downloadableprocessor.php
@@ -264,7 +264,7 @@ class DownloadableProcessor extends Magmi_ItemProcessor
     public function getExistingLinks($pid)
     {
         $dl = $this->tablename('downloadable_link');
-        $sql = "select * from downloadable_link where product_id = ?";
+        $sql = "select * from ".$dl." where product_id = ?";
         $links = $this->selectAll($sql, array($pid));
         return $links;
     }


### PR DESCRIPTION
The downloadable_link table was hard coded, so threw an error if your DB tables have a prefix.