### PR TITLE
Update modman to let composer installer users add there own config

### DIFF
--- a/modman
+++ b/modman
@@ -4,8 +4,12 @@ magmi/conf/magmi.ini.default   magmi/conf/magmi.ini.default
 magmi/engines                  magmi/engines
 magmi/inc                      magmi/inc
 magmi/integration              magmi/integration
-magmi/plugins                  magmi/plugins
-magmi/state                    magmi/state
+magmi/plugins/base             magmi/plugins/base
+magmi/plugins/extra            magmi/plugins/extra
+magmi/plugins/garbocom         magmi/plugins/garbocom
+magmi/plugins/inc              magmi/plugins/inc
+magmi/plugins/utilities        magmi/plugins/utilities
+magmi/state/dummy.txt          magmi/state/dummy.txt
 magmi/tests                    magmi/tests
 magmi/web                      magmi/web
 magmi/.htaccess                magmi/.htaccess

--- a/modman
+++ b/modman
@@ -1,1 +1,12 @@
-magmi/   magmi/
+magmi/build                    magmi/build
+magmi/cli                      magmi/cli
+magmi/conf/magmi.ini.default   magmi/conf/magmi.ini.default
+magmi/engines                  magmi/engines
+magmi/inc                      magmi/inc
+magmi/integration              magmi/integration
+magmi/plugins                  magmi/plugins
+magmi/state                    magmi/state
+magmi/tests                    magmi/tests
+magmi/web                      magmi/web
+magmi/.htaccess                magmi/.htaccess
+magmi/ReleaseNotes.txt         magmi/ReleaseNotes.txt


### PR DESCRIPTION
With this update when using magmi with the composer installer it creates symlinks for everything but lets users still have the config in the right place.