### PR TITLE
Performance optimization for huge numbers of attributes

### DIFF
--- a/magmi/engines/magmi_productimportengine.php
+++ b/magmi/engines/magmi_productimportengine.php
@@ -376,13 +376,13 @@ class Magmi_ProductImportEngine extends Magmi_Engine
     public function initAttrInfos($cols)
     {
         $this->fetchProdEType();
+        $toscan = array();
         
-        // remove from candidates, those which we already know are not attributes
-        $candidates = array_diff($cols, $this->_notattribs);
-        // remove from candidates already known attributes
-        $candidates = array_diff($candidates, array_keys($this->attrinfo));
-        // now we have a count of "unknown columns" that are potential attributes
-        $toscan = array_values($candidates);
+        foreach($cols as $col) {
+            if(!isset($this->_notattribs[$col]) && !isset($this->attrinfo[$col])) {
+                $toscan[] = $col;
+            }
+        }
         if (count($toscan) > 0)
         {
             // create statement parameter string ?,?,?.....
@@ -445,7 +445,10 @@ class Magmi_ProductImportEngine extends Magmi_Engine
                 $this->attrbytype[$bt]["ids"] = implode(",", $idlist);
             }
             // Important Bugfix, array_merge_recurvise to merge 2 dimenstional arrays.
-            $this->_notattribs = array_diff($cols, array_keys($this->attrinfo));
+            $notattribs = array_diff($cols, array_keys($this->attrinfo));
+            foreach($notattribs as $notattrib) {
+                $this->_notattribs[$notattrib] = 1;
+            }
         }
         /*
          * now we have 2 index arrays 1. $this->attrinfo which has the following structure: key : attribute_code value : attribute_properties 2. $this->attrbytype which has the following structure: key : attribute backend type value : array of : data => array of attribute_properties ,one for each attribute that match the backend type ids => list of attribute ids of the backend type


### PR DESCRIPTION
Magmi gets really slow when having a huge set of attributes (which spread across a huge number of attribute sets, each set only having a couple of attributes in my case).
I added some performance tweaks, the most significant being to only process user defined attributes which are in the products attribute set.
These changes boost Magmi by factor 20 for my test case (30.000 products, 1000 attributes, 2000 sets having 6-7 attributes each in average)
Changes are based on 0.7.21 and I'm new to Magento and Magmi and therefore not really sure if I missed some important points, so please review, I'd create a new request based on current master HEAD if changes are OK.
Thanks!