### PR TITLE
prevents blocking of magmi_progress.php while imports

### DIFF
--- a/magmi/web/security.php
+++ b/magmi/web/security.php
@@ -1,6 +1,9 @@
 <?php
 if(session_id()==null) {
     session_start();
+    $CLOSE_AFTER_SECURITY_CHECK = true;
+}else{
+    $CLOSE_AFTER_SECURITY_CHECK = false;
 }
 if(!isset($_REQUEST["token"]) || !isset($_SESSION["token"]) || $_REQUEST["token"]!==$_SESSION["token"])
 {
@@ -10,3 +13,5 @@ if(!isset($_REQUEST["token"]) || !isset($_SESSION["token"]) || $_REQUEST["token"
     echo "RTK:".$_REQUEST["token"];
     exit;
 }
+if($CLOSE_AFTER_SECURITY_CHECK)
+    session_write_close();


### PR DESCRIPTION
This is fix for problem with updating details while imports due to session block.
Other solution is to remove in magmi_progress.php:
```PHP
    session_start();
    $_SESSION["log_error"] = $errors;
    $_SESSION["log_warning"] = $warnings;
    session_write_close();
```
**I'm not sure which idea is better.**