### PR TITLE
Fix security.php blocking session for magmi_progress.php

### DIFF
--- a/magmi/web/security.php
+++ b/magmi/web/security.php
@@ -1,6 +1,7 @@
 <?php
 if(session_id()==null) {
     session_start();
+    session_write_close();
 }
 if(!isset($_REQUEST["token"]) || !isset($_SESSION["token"]) || $_REQUEST["token"]!==$_SESSION["token"])
 {


### PR DESCRIPTION
Fixed
* security.php blocks other requests (e.g. magmi_run.php and magmi_progress.php) when running an import with "old" frontend by calling session_start() without session_write_close()