### PR TITLE
Remove magento-composer-installer requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
     "name": "dweeves/magmi",
-    "type": "magento-module",
     "description": "Magento Mass Importer",
     "license": "MIT License",
     "homepage": "http://sourceforge.net/projects/magmi/",
@@ -8,8 +7,5 @@
         {
             "name":"Sebastien Bracquemont"
         }
-    ],
-    "require": {
-        "magento-hackathon/magento-composer-installer": "*"
-    }
+    ]
 }


### PR DESCRIPTION
Not sure if there is any point of installing magmi as magento module but for sure using magmi with pure composer does not require magento-composer-installer and 7 derived dependencies to be downloaded.

Also prompt to define Magento root is breaking the build.