### PR TITLE
added attribute set importer v0.0.1

### DIFF
--- a/magmi/inc/array_reader.php
+++ b/magmi/inc/array_reader.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * <p>This class can replace a CSVReader as a datasource for the updateGeneric() function of AttributeSetImporter,
+ * it simply does not read data from a CSV file but from an array.</p>
+ *
+ */
+class ArrayReader {
+    protected $_array;
+    protected $_leftKeys;
+    protected $_currentKey=null;
+    protected $_columnNames = array();
+
+    public function initialize($array) {
+        $this->_array = $array;
+        $this->_leftKeys = array_keys($array);
+        $this->_currentKey = array_shift($this->_leftKeys);
+        if(isset($currentKey)) {
+            $this->_columnNames = array_keys($this->_array[$this->_currentKey]);
+        }
+    }
+
+    public function getColumnNames($prescan = false)
+    {
+        return $this->_columnNames;
+    }
+
+    public function getLinesCount()
+    {
+        return sizeof($this->_array);
+    }
+
+    public function getNextRecord()
+    {
+        if(!isset($this->_currentKey)) {
+            return null;
+        } else {
+            $record = $this->_array[$this->_currentKey];
+            $this->_currentKey = array_shift($this->_leftKeys);
+            return $record;
+        }
+    }
+
+    public function onException($e)
+    {}
+}
+?>

--- a/magmi/inc/dbhelper.class.php
+++ b/magmi/inc/dbhelper.class.php
@@ -20,6 +20,7 @@ class DBHelper
     protected $prepared = array();
     protected $_timecounter = null;
     protected $_tcats;
+    protected $_tables2columns = array();
 
     public function __construct()
     {
@@ -656,6 +657,24 @@ class DBHelper
         if ($return)
         {
             return $results;
+        }
+    }
+    
+    /**
+     * Returns an array of columns names for the given table name.
+     * @param string $tablename name of the table (without table prefix, as it will be applied)
+     */
+    public function cols($tablename) {
+        if(isset($this->_tables2columns[$tablename])) {
+            return $this->_tables2columns[$tablename];
+        } else {
+            $columnNames = array();
+            $data = $this->select("SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = ?",array($this->tablename($tablename)));
+            foreach($data as $record) {
+                $columnNames[] = $record['COLUMN_NAME'];
+            }
+            $this->_tables2columns[$tablename] = $columnNames;
+            return $columnNames;
         }
     }
 }

--- a/magmi/inc/magmi_csvreader.php
+++ b/magmi/inc/magmi_csvreader.php
@@ -19,15 +19,17 @@ class Magmi_CSVReader extends Magmi_Mixin
     protected $_nhcols;
     protected $_cenc;
     protected $_ignored = array();
+    protected $_prefix;
 
-    public function initialize($params=null)
+    public function initialize($params=null,$prefix='CSV')
     {
+    	$this->_prefix = $prefix;
     	if(isset($params))
     	{
     		$this->_params=$params;
     	}
-        $this->_filename = $this->getParam("CSV:filename");
-        $this->_csep = $this->getParam("CSV:separator", ",");
+        $this->_filename = $this->getParam($this->_prefix.":filename");
+        $this->_csep = $this->getParam($this->_prefix.":separator", ",");
         $this->_dcsep = $this->_csep;
         
         if ($this->_csep == "\\t")
@@ -35,9 +37,9 @@ class Magmi_CSVReader extends Magmi_Mixin
             $this->_csep = "\t";
         }
         
-        $this->_cenc = $this->getParam("CSV:enclosure", '"');
-        $this->_buffersize = $this->getParam("CSV:buffer", 0);
-        $this->_ignored = explode(",", $this->getParam("CSV:ignore"));
+        $this->_cenc = $this->getParam($this->_prefix.":enclosure", '"');
+        $this->_buffersize = $this->getParam($this->_prefix.":buffer", 0);
+        $this->_ignored = explode(",", $this->getParam($this->_prefix.":ignore"));
     }
     
     public function getParam($paramname,$default='')
@@ -49,7 +51,7 @@ class Magmi_CSVReader extends Magmi_Mixin
     {
         // open csv file
         $f = fopen($this->_filename, "rb");
-        if ($this->getParam("CSV:noheader", false) == true)
+        if ($this->getParam($this->_prefix.":noheader", false) == true)
         {
             $count = 0;
         }
@@ -60,7 +62,7 @@ class Magmi_CSVReader extends Magmi_Mixin
         if ($f != false)
         {
             $line = 1;
-            while ($line < $this->getParam("CSV:headerline", 1))
+            while ($line < $this->getParam($this->_prefix.":headerline", 1))
             {
                 $line++;
                 fgetcsv($f, $this->_buffersize, $this->_csep, $this->_cenc);
@@ -123,7 +125,7 @@ class Magmi_CSVReader extends Magmi_Mixin
         if ($prescan == true)
         {
             $this->openCSV();
-            $this->_csep = $this->getParam("CSV:separator", ",");
+            $this->_csep = $this->getParam($this->_prefix.":separator", ",");
             $this->_dcsep = $this->_csep;
             
             if ($this->_csep == "\\t")
@@ -131,13 +133,13 @@ class Magmi_CSVReader extends Magmi_Mixin
                 $this->_csep = "\t";
             }
             
-            $this->_cenc = $this->getParam("CSV:enclosure", '"');
-            $this->_buffersize = $this->getParam("CSV:buffer", 0);
+            $this->_cenc = $this->getParam($this->_prefix.":enclosure", '"');
+            $this->_buffersize = $this->getParam($this->_prefix.":buffer", 0);
         }
         
         $line = 1;
         
-        while ($line < $this->getParam("CSV:headerline", 1))
+        while ($line < $this->getParam($this->_prefix.":headerline", 1))
         {
             $line++;
             $dummy = fgetcsv($this->_fh, $this->_buffersize, $this->_csep, $this->_cenc);
@@ -145,7 +147,7 @@ class Magmi_CSVReader extends Magmi_Mixin
         }
         $cols = fgetcsv($this->_fh, $this->_buffersize, $this->_csep, $this->_cenc);
         // if csv has no headers,use column number as column name
-        if ($this->getParam("CSV:noheader", false) == true)
+        if ($this->getParam($this->_prefix.":noheader", false) == true)
         {
             $kl = array_merge(array("dummy"), $cols);
             unset($kl[0]);
@@ -189,7 +191,7 @@ class Magmi_CSVReader extends Magmi_Mixin
     public function getNextRecord()
     {
         $row = null;
-        $allowtrunc = $this->getParam("CSV:allowtrunc", false);
+        $allowtrunc = $this->getParam($this->_prefix.":allowtrunc", false);
         while ($row !== false)
         {
             $row = fgetcsv($this->_fh, $this->_buffersize, $this->_csep, $this->_cenc);

--- a/magmi/integration/inc/attributeset_datapump.php
+++ b/magmi/integration/inc/attributeset_datapump.php
@@ -1,0 +1,30 @@
+<?php 
+require_once ("productimport_datapump.php");
+require_once ("array_reader.php");
+
+class Magmi_AttributeSet_DataPump extends Magmi_ProductImport_DataPump {
+    
+    
+    public function ingestAttributes($items = array())
+    {
+        $reader = new ArrayReader();
+        $reader->initialize($items);
+        $this->_engine->callPlugins("general", "importAttributes", $reader);
+    }
+    
+    public function ingestAttributeSets($items = array())
+    {
+        $reader = new ArrayReader();
+        $reader->initialize($items);
+        $this->_engine->callPlugins("general", "importAttributeSets", $reader);
+    }
+    
+    public function ingestAttributeAsociations($items = array())
+    {
+        $reader = new ArrayReader();
+        $reader->initialize($items);
+        $this->_engine->callPlugins("general", "importAttributeAssociations", $reader);
+    }
+    
+}
+?>

--- a/magmi/integration/inc/pumpfactory.ini
+++ b/magmi/integration/inc/pumpfactory.ini
@@ -1,2 +1,3 @@
 [DATAPUMPS]
 productimport=productimport_datapump::Magmi_ProductImport_Datapump
+attributesetimport=attributeset_datapump::Magmi_AttributeSet_DataPump

--- a/magmi/plugins/5b5/general/attributesetimport/additional_data_csv_reader.php
+++ b/magmi/plugins/5b5/general/attributesetimport/additional_data_csv_reader.php
@@ -1,0 +1,146 @@
+<?php
+
+/**
+ * <p>Extension of Magmi_CSVReader which allows to manually add records.</p>
+ *
+ */
+class AdditionalDataCSVReader extends Magmi_CSVReader {
+    
+    /**
+     * Only used when using addWildcardData functions.
+     * Stores all used values in original (CSV) data for each column.
+     * @var array (column name => array of values)
+     */
+    private $_availableValuesPerColumn=null;
+    
+    /**
+     * Array storing the manually added data.
+     * @var array of records( array ( column name => column data ) )
+     */
+    private $_addedData=array();
+    
+    /**
+     * Index for iteration.
+     * @var integer
+     */
+    private $_currentIndex = 0;
+
+    /**
+     * Reads all CSV data into $this->_availableValuesPerColumn.
+     */
+    private function readValues() {
+        $this->openCSV();
+        $this->getColumnNames();
+        $this->_availableValuesPerColumn=[];
+        while($record = $this->getNextRecord()) {
+            foreach($record as $columnName => $value) {
+                if(!isset($this->_availableValuesPerColumn[$columnName])) {
+                    $this->_availableValuesPerColumn[$columnName] = array();
+                }
+                $this->_availableValuesPerColumn[$columnName][$value] = 1;
+            }
+        }
+        $this->closeCSV();
+    }
+
+    /**
+     * <p>Takes a single record and if one of the column values of the record
+     * has a value of "*", mutliples the record by generating records with the same values
+     * but replacing the "*" value with each used value for the same column from the CSV source. Then returns
+     * an array with all generated records.
+     * Calls expandWildcards recursively on the generated records, to replace/expand asterisk values in other columns as well.
+     * If none of the values is "*", then an array containing only the given record is returned.</p>
+     * @param array $record as associative array (column name => column value)
+     * @return array of generated/expanded records
+     */
+    private function inflateWildcardsSingle($record) {
+        foreach($record as $columnName => $value) {
+            if($value === "*") {
+                $expandedRecords = array();
+                foreach($this->_availableValuesPerColumn[$columnName] as $value => $ignore) {
+                    $newRecord = $record;
+                    $newRecord[$columnName] = $value;
+                    $expandedRecords[] = $newRecord;
+                }
+                return $this->inflateWildcards($expandedRecords);
+            }
+        }
+        return array($record);
+    }
+    
+    /**
+     * <p>Calls expandWildcardsSingle for each record in the given array and merges the results into one array.</p>
+     * @param array $records array of records
+     * @return array of expanded records
+     */
+    private function inflateWildcards($records) {
+        $newRecords = array();
+        foreach($records as $record) {
+            $newRecords = array_merge($newRecords,$this->inflateWildcardsSingle($record));
+        }
+        return $newRecords;
+    }
+
+    /**
+     * <p>Adds the given data (given as a csv formatted string with headers in first line)
+     * to the CSV Reader data. Wildcards ("*") are allowed to inflate data for every possible value in this column.</p>
+     * 
+     * @param string $csv data to add as a csv formatted multiline string
+     */
+    public function addWildcardDataCSV($csv) {
+        $records = array();
+        $lines = explode("\n",$csv);
+        $firstLine = array_shift($lines);
+        $columnNames = str_getcsv($firstLine);
+        while(sizeof($lines) > 0) {
+            $currentLine = array_shift($lines);
+            $data = str_getcsv($currentLine);
+            $records[] = array_combine($columnNames, $data);
+        }
+        $this->addWildcardData($records);
+    }
+
+    /**
+     * <p>Adds the given data (given as an array of records (each by itself an associative array of the form column name => column value)) to the CSV Reader data.
+     * Wildcards ("*") are allowed to inflate data for every possible value in this column.</p>
+     * 
+     * @param string $csv data to add as a csv formatted multiline string
+     */
+    public function addWildcardData($data) {
+        if(!isset($this->_availableValuesPerColumn)) {
+            $this->readValues();
+        }
+        $this->_addedData = $this->inflateWildcards($data);
+    }
+
+    /**
+     * (non-PHPdoc)
+     * @see Magmi_CSVReader::getLinesCount()
+     */
+    public function getLinesCount() {
+        return (parent::getLinesCount()+sizeof($this->_addedData));
+    }
+
+    /**
+     * (non-PHPdoc)
+     * @see Magmi_CSVReader::openCSV()
+     */
+    public function openCSV() {
+        $this->_currentIndex = 0;
+        return parent::openCSV();
+    }
+
+    /**
+     * (non-PHPdoc)
+     * @see Magmi_CSVReader::getNextRecord()
+     */
+    public function getNextRecord() {
+        $result = parent::getNextRecord();
+        if(!$result && sizeof($this->_addedData) > $this->_currentIndex) {
+            $result = $this->_addedData[$this->_currentIndex];
+            $this->_currentIndex++;
+        }
+        return $result;
+    }
+}
+?>

--- a/magmi/plugins/5b5/general/attributesetimport/attributesetimport.mediawiki
+++ b/magmi/plugins/5b5/general/attributesetimport/attributesetimport.mediawiki
@@ -1,0 +1,454 @@
+== What it does ==
+It imports attributes, attribute sets with groups and the corresponding attribute-to-set associations from 3 different csv files to the magento database before the product update will start.
+It lets you choose for each entity type (attributes, sets, associations) if you want to update existing, create new, delete marked records and/or prune all records which were not given in your import data.
+
+== Usage ==
+
+=== Configuration options ===
+The plugin offers nearly the same configuration options for each of the three entity types:
+
+==== Enable <entity type> import  ====
+The import for each entity type can be separately switched on/off.
+
+==== CSV import mode / CSV options ====
+These are exactly the same as for the product import datasources configuration (because the plugin uses the same CSVReader class).
+These options handle the CSV options for each entity type separately. (Because there should be a CSV file each.)
+
+==== Default values ====
+Default values are used if all imported entries should have the same values for one or more columns. You can save the column in your CSV file and just set a default value.
+The default values for non-existing columns are given as a JSON-style Object:
+e.g. if you want to set "is_user_defined" and "is_visible" to 1 and "default_value" to "Test" by default, you would enter:
+ {"is_user_defined":1,"is_visible":1,"default_value":"Test"}
+
+==== Switch "Prune <entity type> which are not given" ====
+If you activate this switch, the import will first update/insert the records from your CSV file and afterwards iterate over all existing records in the database and delete all of them, which are not given in the CSV file. This is a good option if you always export the full list of records and want to keep your database clean. This is not intended for incremental updates, of course...
+
+If this switch is activated, there are some more options:
+===== Don't touch non-user attributes (only attributes and associations) =====
+If this switch is activated, the pruning will only affect attributes which have "is_user_defined" set to 1.
+
+===== Keep <entity type> when pruning =====
+For attributes and attribute sets this is straight forward:
+Just enter attribute codes or attribute set names (separated by comma) which shall be spared from pruning.
+ name,description,price,sku
+
+For associations this is slightly more complex:
+If you enter a comma-separated list like with the other two entity types, the values will be interpreted as attribute set names. All associations for these attribute sets are spared from pruning.
+There is also a second possibility:
+If you use JSON-style array notation there is more control over what will be kept and what will be pruned, e.g.:
+ [['Default'],['Set1','name'],['Set2','name','Group1']]
+will keep ALL associations of any attribute to attribute set 'Default', the association of attribute 'name' with attribute set 'Set1' regardless of in which group the attribute is, and the association of attribute 'name' with attribute set 'Set2' but only if it is in group 'Group1'.
+The inner arrays are ordered, the order is always 'set name','attribute code','group name' and values can only be omitted from the right.
+If you need more flexibility, also have a look at the [[#Add these attribute associations to given CSV data]] option!
+
+==== Delete <entity type> marked "magmi:delete" = 1 ====
+'''magmi:delete''' is used just like in the Product Deleter plugin. If this option is activated and you add a column names "magmi:delete" to your CSV file, each record having a "1" in this column will be deleted.
+
+==== Create <entity type> from CSV which are not in database ====
+If this switch is active, records from CSV wich don't exist in the database will be created according to the given data.
+If the switch is not active, records which are not already in the database will be ignored.
+
+==== Update <entity type> from CSV which are already in database ====
+If this switch is enabled, records from CSV wich already exist in the database will be compared to the given data from your CSV file and if there are changes, the database record will be updated.
+If the switch is not active, records which are already in database will be ignored, regardless if they have the same or different content as in the database.
+
+==== Attribute Set Groups import ====
+Groups import is only enabled if either the create or the update switch is active for entity type "attribute sets".
+The options for groups import are the same as for the other imports, the only difference is, groups belong to an attribute set and therefore, groups are given with each attribute set record.
+Within attribute set CSV data a column "magmi:groups" may be added. The format of this column's data is as follows:
+<group name>:<sort order>,<group name>:<sort order>,<group name>:<sort order>
+So, if you want to set three groups for an attribute set named "Group1", "Group2" and "Group3", you would probably set
+ Group1:1,Group2:2,Group3:3
+as the value for "magmi:groups" column in the atrribute set's CSV row.
+The colon and following sort order may be omitted, the sort order is calculated as <sort order of previous element plus 1>, if no sort order is given for the first element, it will obtain sort order 0.
+One of the groups may optionally be set as the default group by giving its name in an extra column "magmi:default_group".
+
+''All options for group import have a "per attribute set" focus, so will only have effect for updated/imported attribute sets.''
+
+==== Add these attribute associations to given CSV data ====
+This text area allows to add more records which will be appended before import. A fixed CSV format is used (comma-separated, optionally enclosed by "). 
+The first line should therefore contain the column names (attribute_set_name,attribute_code,attribute_group_name) in your preferred order.
+The following lines contain the additional data rows (obviously in the same order).
+
+Seems easy but not very useful, though?
+There is one specialty: A single asterisk "*" may be used as value for attribute set names to denote "add this attribute to each attribute set given within the original CSV file".
+This allows to define a default set of attributes for each attribute set without putting these default attributes in the CSV file on each export.
+
+=== CSV data format ===
+==== General considerations about import files ====
+From the plugin's perspective, the only mandatory columns in the CSV files are the "name" columns identifying the record (attribute_code for attributes, attribute_set_name for attribute sets, both of them for associations).
+All further columns will be inserted/updated if given or just ignored if not. (Further columns would nevertheless be mandatory if the value is not nullable AND there is no default value in database, fortunately this is not the case.).
+All other column names from the respective database tables can be used as columns in the CSV data, just don't use the primary key columns! The records are identified by the "names" and using primary keys columns in CSV could or most likely will lead to destroyed data in your database! If column names don't match between CSV and database, the data will be ignored (there will be no error message). In other words: extra columns are ignored.
+There are a few extra columns defined by this plugin: "magmi:delete" (all entity types, see [[Delete <entity type> marked "magmi:delete" = 1]]), "magmi:groups" and "magmi:default_group" (only for attribute sets, see [[#Attribute Set Groups import]]).
+
+
+==== Entity type "Attribute" ====
+Updates database tables '''eav_attribute''' and '''catalog_eav_attribute'''.
+Identified by '''attribute_code'''
+
+{| cellpadding="5" cellspacing="0" border="1"
+!Column name
+!type
+!mandatory
+!default value (on insert if column is omitted)
+!COMMENT
+|-
+|attribute_id
+|smallint
+|DON'T USE!
+|auto
+|Don't use! This is the primary key.
+|-
+|entity_type_id
+|smallint
+|DON'T USE!
+|depends...
+|The plugin already cares for the correct value!
+|-
+|attribute_code
+|varchar
+|YES
+| --
+|This is how the attribute is identified by the plugin.
+|-
+|attribute_model
+|varchar
+|NO
+|null
+|
+|-
+|backend_model
+|varchar
+|NO
+|null
+|
+|-
+|backend_type
+|varchar
+|NO
+|"static"
+|
+|-
+|backend_table
+|varchar
+|NO
+|null
+|
+|-
+|frontend_model
+|varchar
+|NO
+|null
+|
+|-
+|frontend_input
+|varchar
+|NO
+|null
+|
+|-
+|frontend_label
+|varchar
+|NO
+|null
+|
+|-
+|frontend_class
+|varchar
+|NO
+|null
+|
+|-
+|source_model
+|varchar
+|NO
+|null
+|
+|-
+|is_required
+|smallint
+|NO
+|0
+|
+|-
+|is_user_defined
+|smallint
+|NO
+|0
+|
+|-
+|default_value
+|text
+|NO
+|null
+|
+|-
+|is_unique
+|smallint
+|NO
+|0
+|
+|-
+|note
+|varchar
+|NO
+|null
+|
+|-
+|frontend_input_renderer
+|varchar
+|NO
+|null
+|
+|-
+|is_global
+|smallint
+|NO
+|1
+|
+|-
+|is_visible
+|smallint
+|NO
+|1
+|
+|-
+|is_searchable
+|smallint
+|NO
+|0
+|
+|-
+|is_filterable
+|smallint
+|NO
+|0
+|
+|-
+|is_comparable
+|smallint
+|NO
+|0
+|
+|-
+|is_visible_on_front
+|smallint
+|NO
+|0
+|
+|-
+|is_html_allowed_on_front
+|smallint
+|NO
+|0
+|
+|-
+|is_used_for_price_rules
+|smallint
+|NO
+|0
+|
+|-
+|is_filterable_in_search
+|smallint
+|NO
+|0
+|
+|-
+|used_in_product_listing
+|smallint
+|NO
+|0
+|
+|-
+|used_for_sort_by
+|smallint
+|NO
+|0
+|
+|-
+|is_configurable
+|smallint
+|NO
+|1
+|
+|-
+|apply_to
+|varchar
+|NO
+|null
+|
+|-
+|is_visible_in_advanced_search
+|smallint
+|NO
+|0
+|
+|-
+|position
+|int
+|NO
+|0
+|
+|-
+|is_wysiwyg_enabled
+|smallint
+|NO
+|0
+|
+|-
+|is_used_for_promo_rules
+|smallint
+|NO
+|0
+|
+|-
+|magmi:delete
+|smallint
+|NO
+|0
+|
+|-
+|}
+
+==== Entity type "Attribute Set" ====
+Updates database table '''eav_attribute_set'''
+Identified by '''attribute_set_name'''
+
+{| cellpadding="5" cellspacing="0" border="1"
+!Column name
+!type
+!mandatory
+!default value (on insert if column is omitted)
+!COMMENT
+|-
+|attribute_set_id
+|smallint
+|DON'T USE!
+|auto
+|Don't use! This is the primary key.
+|-
+|entity_type_id
+|smallint
+|DON'T USE!
+|depends...
+|The plugin already cares for the correct value!
+|-
+|attribute_set_name
+|varchar
+|YES
+| --
+|This is how the attribute set is identified by the plugin.
+|-
+|sort_order
+|smallint
+|NO
+|0
+|
+|}
+
+==== Entity type "Attribute to attribute set association" ====
+Updates database table '''eav_entity_attribute'''
+Identified by '''attribute_set_name''' and '''attribute_code'''
+
+{| cellpadding="5" cellspacing="0" border="1"
+!Column name
+!type
+!mandatory
+!default value (on insert if column is omitted)
+!COMMENT
+|-
+|entity_attribute_id
+|smallint
+|DON'T USE!
+|auto
+|Don't use! This is the primary key.
+|-
+|entity_type_id
+|smallint
+|DON'T USE!
+|depends...
+|The plugin already cares for the correct value!
+|-
+|attribute_set_id
+|smallint
+|NO
+| --
+|Don't use this, unless you want to give the database id of the attribute set, use 'attribute_set_name' instead!
+|-
+|attribute_set_name
+|smallint
+|YES (unless you use attribute_set_id)
+| --
+|Will be transformed to attribute_set_id on the fly while plugin execution.
+|-
+|attribute_id
+|smallint
+|NO
+| --
+|Don't use this, unless you want to give the database id of the attribute, use 'attribute_code' instead!
+|-
+|attribute_code
+|smallint
+|YES (unless you use attribute_id)
+| --
+|Will be transformed to attribute_id on the fly while plugin execution.
+|-
+|attribute_group_id
+|smallint
+|NO
+| --
+|Don't use this, unless you want to give the datbase id of the group, use 'attribute_group_name' instead!
+|-
+|attribute_group_name
+|smallint
+|YES (unless you use attribute_group_id)
+| --
+|Will be transformed to attribute_group_id on the fly while plugin execution.
+|-
+|sort_order
+|smallint
+|NO
+|0
+|
+|}
+
+== Datapump functionality ==
+'''''CAUTION! This functionality is almost untested!'''''
+
+There is an extension to the DataPump API which can be obtained by using
+ $dp=Magmi_DataPumpFactory::getDataPumpInstance("attributesetimport");
+
+This extension works exactly the same as the normal DataPump API (you could even also import products with the ingest() function), it just defines the additional functions
+ ingestAttributes($arrayWithAttributes);
+ ingestAttributeSets($arrayWithAttributeSets);
+ ingestAttributeAssociations($arrayWithAttributeAssociations);
+
+Other than the product data ingest function these functions don't take a single record in a single associative array, but an array of arrays (records) which is necessary to be able to use the "prune" functionality.
+All CSV related options will simply be ignored when using DataPump API. The "import behavior" options stay active!
+
+Example (based on default DataPump example):
+ <?php
+ // assuming that your script file is located in magmi/integration/scripts/somedirectory/myscript.php,
+ // include "magmi_defs.php" , once done, you will be able to use any magmi includes without specific path.
+ require_once("../../../inc/magmi_defs.php");
+ //Datapump include
+ require_once("magmi_datapump.php");
+ 
+ // Difference to "normal" datapump!!! Create an Attribute Set import Datapump using Magmi_DatapumpFactory
+ $dp=Magmi_DataPumpFactory::getDataPumpInstance("attributesetimport");
+ 
+ // Begin import session with a profile & running mode, here profile is "default" & running mode is "create".
+ // Available modes: "create" creates and updates items, "update" updates only, "xcreate creates only.
+ // Important: for values other than "default" profile has to be an existing magmi profile
+ $dp->beginImportSession("default","create");
+ 
+ // attribute datapump function take an array of arrays (submitting multiple records at once)
+ $testitems=array(array("attribute_set_name"=>"datapump test"),array("attribute_set_name"=>"datapump test2"));
+ 
+ // Now ingest item(s) into magento
+ $dp->ingestAttributeSets($testitems);
+ 
+ // End import Session
+ $dp->endImportSession();
+ ?>

--- a/magmi/plugins/5b5/general/attributesetimport/attributesetimport.php
+++ b/magmi/plugins/5b5/general/attributesetimport/attributesetimport.php
@@ -1,0 +1,914 @@
+<?php
+require_once ("magmi_csvreader.php");
+require_once ("fshelper.php");
+require_once ("additional_data_csv_reader.php");
+require_once ("array_reader.php");
+require_once ("multi_dim_array.php");
+require_once ("name2id_decoding.php");
+
+/**
+ * Attribute/Attribute Set/Attribute Set Associations importer plugin for Magmi framework
+ * 
+ * This Plugin imports attributes, attribute sets with groups and the corresponding attribute-to-set associations from 3 different csv files to the magento database before the product update will start.
+ * It lets you choose for each entity type (attributes, sets, associations) if you want to update existing, create new, delete marked records and/or prune all records which were not given in your import data.
+ *
+ * @author 5byfive GmbH (T.Rosenstiel) based on code (Magmi framework, particularly CSVReader and CSV Options) by Dweeves
+ * 
+ * Copyright (C) 2015 by 5byfive GmbH (T. Rosenstiel) and Dweeves (S.BRACQUEMONT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+class AttributeSetImporter extends Magmi_GeneralImportPlugin
+{
+    /**
+     * Variable storing the entity type id (dynamically fetched from database in fetchProdEType() )
+     * @var integer
+     */
+    protected $_prod_etype;
+    
+    /**
+     * Config parameters for call to updateGeneric when processing attributes.
+     * @var array
+     */
+    private $ATTRIBUTE_ARGS = [
+                    'entityName'=>"attribute",
+                    'tables'=>['eav_attribute','catalog_eav_attribute'],
+                    'idColName'=>'attribute_id',
+                    'nameColNames'=>['attribute_code'],
+                    'elementPrefix'=>'5B5ATI',
+                    'verbose'=>true,
+                    'fetchSystemAttributeIdsSql'=>"select attribute_id from ##eav_attribute## where is_user_defined = 0"
+            ];
+    
+    /**
+     * Config parameters for call to updateGeneric when processing attribute sets.
+     * @var array
+     */
+    private $ATTRIBUTE_SET_ARGS = [
+                    'entityName'=>"attribute set",
+                    'tables'=>['eav_attribute_set'],
+                    'idColName'=>'attribute_set_id',
+                    'nameColNames'=>['attribute_set_name'],
+                    'elementPrefix'=>'5B5ASI',
+                    'verbose'=>true
+    ];
+    
+    /**
+     * Config parameters for call to updateGeneric when processing attribute set associations.
+     * @var array
+     */
+    private $ATTRIBUTE_SET_ASSOCIATION_ARGS = [
+                    'entityName'=>"attribute association",
+                    'tables'=>['eav_entity_attribute'],
+                    'idColName'=>'entity_attribute_id',
+                    'nameColNames'=>['attribute_set_id','attribute_id','attribute_group_id'],
+                    'elementPrefix'=>'5B5AAI',
+                    'verbose'=>true,
+                    'fetchSystemAttributeIdsSql'=>"select entity_attribute_id from ##eav_entity_attribute## where attribute_id in (select attribute_id from ##eav_attribute## where is_user_defined = 0)"
+    ];
+    
+    /**
+     * Configuration for the Name2IdDecoder used for attribute associations "decoding".
+     * @var array
+     */
+    private $ATTRIBUTE_SET_ASSOCIATION_DECODER_ARGS = [
+                            'attribute_set_name'
+                                =>[
+                                    'tableName' => 'eav_attribute_set',
+                                    'nameColumnName' => 'attribute_set_name',
+                                    'idColumnName' => 'attribute_set_id'
+                                ],
+                            'attribute_code'
+                                =>[
+                                    'tableName' => 'eav_attribute',
+                                    'nameColumnName' => 'attribute_code',
+                                    'idColumnName' => 'attribute_id'
+                                ],
+                            'attribute_group_name'
+                                =>[
+                                    'tableName' => 'eav_attribute_group',
+                                    'nameColumnName' => 'attribute_group_name',
+                                    'idColumnName' => 'attribute_group_id',
+                                    'additionalIdColumn' => 'attribute_set_id'
+                                ]
+    ];
+    
+    /**
+     * Config parameters for call to updateGeneric when processing attribute set groups.
+     * @var array
+     */
+    private $ATTRIBUTE_GROUP_ARGS = [
+                'entityName'=>"attribute group",
+                'tables'=>['eav_attribute_group'],
+                'idColName'=>'attribute_group_id',
+                'nameColNames'=>['attribute_group_name'],
+                'elementPrefix'=>'5B5AGI',
+                'verbose'=>false
+    ];
+    
+    public function initialize($params)
+    {
+    }
+
+    /**
+     * Copied from CSV_Datasource (redesign class structure?)
+     * 
+     * @param string $prefix the prefix to use when retreiving options values from configuration (without ':')
+     * @param string $resolve if set to true,return associated realpath
+     */
+    public function getScanDir($prefix,$resolve = true)
+    {
+        $scandir = $this->getParam($prefix.":basedir", "var/import");
+        if (!isabspath($scandir))
+        {
+            $scandir = abspath($scandir, Magmi_Config::getInstance()->getMagentoDir(), $resolve);
+        }
+        return $scandir;
+    }
+
+    /**
+     * Copied from CSV_Datasource (redesign class structure?)
+     * @param string $prefix the prefix to use when retreiving options values from configuration (without ':')
+     */
+    public function getCSVList($prefix)
+    {
+        $scandir = $this->getScanDir($prefix);
+        $files = glob("$scandir/*.csv");
+        return $files;
+    }
+
+    public function getPluginParams($params)
+    {
+        $pp = array();
+        foreach ($params as $k => $v)
+        {
+            // This plugin is using multiple plugin param prefixes!
+            if (preg_match("/^5B5A[TSAG]I:.*$/", $k))
+            {
+                $pp[$k] = $v;
+            }
+        }
+        return $pp;
+    }
+
+    public function getPluginInfo()
+    {
+        return array("name"=>"Attribute Set Importer","author"=>"5byfive GmbH","version"=>"0.0.1","url"=>$this->pluginDocUrl("5b5_Attribute_Set_Importer"));
+    }
+
+    /**
+     * Copied from CSV_Datasource (redesign class structure?)
+     * @param string $prefix the prefix to use when retreiving options values from configuration (without ':')
+     * @param string $url url to fetch
+     */
+    public function getRemoteFile($prefix,$url)
+    {
+        $fg = RemoteFileGetterFactory::getFGInstance();
+        if ($this->getParam($prefix.":remoteauth", false) == true)
+        {
+            $user = $this->getParam($prefix.":remoteuser");
+            $pass = $this->getParam($prefix.":remotepass");
+            $fg->setCredentials($user, $pass);
+        }
+        $cookies = $this->getParam($prefix.":remotecookie");
+        if ($cookies)
+        {
+            $fg->setCookie($cookies);
+        }
+        
+        $this->log("Fetching $prefix: $url", "startup");
+        // output filename (current dir+remote filename)
+        $csvdldir = dirname(__FILE__) . "/downloads";
+        if (!file_exists($csvdldir))
+        {
+            @mkdir($csvdldir);
+            @chmod($csvdldir, Magmi_Config::getInstance()->getDirMask());
+        }
+        
+        $outname = $csvdldir . "/" . basename($url);
+        $ext = substr(strrchr($outname, '.'), 1);
+        if ($ext != "txt" && $ext != "csv")
+        {
+            $outname = $outname . ".csv";
+        }
+        // open file for writing
+        if (file_exists($outname))
+        {
+            if ($this->getParam($prefix.":forcedl", false) == true)
+            {
+                unlink($outname);
+            }
+            else
+            {
+                return $outname;
+            }
+        }
+        $fg->copyRemoteFile($url, $outname);
+        
+        // return the csv filename
+        return $outname;
+    }
+    
+    
+    /**
+     * <p>Gets the options for the import file from the plugin options (uses options with given prefix),
+     * initializes and opens the CSVReader for further processing.
+     * For attribute association import also initializes the AdditionalDataCSVReader as a wrapper for the CSVReader.</p>
+     * @param string $prefix the prefix to use when retreiving options values from configuration (without ':')
+     */
+    private function prepareCSV($prefix) {
+        $csvreader = new Magmi_CSVReader();
+        
+        // for attribute asociations use AdditionalDataCSVReader
+        if($prefix == '5B5AAI') $csvreader = new AdditionalDataCSVReader();
+        $csvreader->bind($this);
+        $csvreader->initialize($this->getParams(),$prefix);
+        if ($this->getParam($prefix.":importmode", "local") == "remote")
+        {
+            $url = $this->getParam($prefix.":remoteurl", "");
+            $outname = $this->getRemoteFile($prefix,$url);
+            $this->setParam($prefix.":filename", $outname);
+            $csvreader->initialize($this->_params);
+        }
+        $csvreader->checkCSV();
+        
+        // add additional (wildcarded) data for attribute associations
+        if($prefix == '5B5AAI') {
+            $this->log('Appending/inflating data with configured data...','startup');
+            $csvreader->addWildcardDataCSV($this->getParam('5B5AAI:default_rows',''));
+            $this->log('Finished appending data','startup');
+        }
+        $csvreader->openCSV();
+        $csvreader->getColumnNames();
+        return $csvreader;
+    }
+    
+    /**
+     * Performs the attribute import.
+     */
+    public function importAttributes($csvreader) {
+        $this->fetchProdEType();
+        // condition to restrict on product entity type (will be given as default and fetchConditions to updateGeneric() function
+        $etiCondition = ['entity_type_id' => $this->_prod_etype];
+        $this->updateGeneric($csvreader,$this->ATTRIBUTE_ARGS,$etiCondition,$etiCondition);
+    }
+
+
+    /**
+     * Performs the attribute set import.
+     */
+    public function importAttributeSets($csvreader) {
+        $this->fetchProdEType();
+        // condition to restrict on product entity type (will be given as default and fetchConditions to updateGeneric() function
+        $etiCondition = ['entity_type_id' => $this->_prod_etype];
+        $this->updateGeneric($csvreader,$this->ATTRIBUTE_SET_ARGS,$etiCondition,$etiCondition);
+    }
+    
+    /**
+     * Performs the attribute associations import.
+     */
+    public function importAttributeAssociations($csvreader) {
+        $this->fetchProdEType();
+        // condition to restrict on product entity type (will be given as default and fetchConditions to updateGeneric() function
+        $etiCondition = ['entity_type_id' => $this->_prod_etype];
+        
+        // dynamically add product entity type id to decoder options
+        $decoderArgs = array_merge_recursive($this->ATTRIBUTE_SET_ASSOCIATION_DECODER_ARGS,
+                ['attribute_set_name'=>['conditions' =>['entity_type_id' => $this->_prod_etype]],
+                        'attribute_code'=>['conditions' =>['entity_type_id' => $this->_prod_etype]]]);
+        
+        $decoder = new Name2IdDecoder($this,$decoderArgs);
+        $this->updateGeneric($csvreader,$this->ATTRIBUTE_SET_ASSOCIATION_ARGS,$etiCondition,$etiCondition,$decoder);
+    }
+    
+    /**
+     * (non-PHPdoc)
+     * The import logic is implemented in beforeImport because the attribute import should be done BEFORE importing the products.
+     * @see Magmi_GeneralImportPlugin::beforeImport()
+     */
+    public function beforeImport()
+    {
+        $this->log('Attribute Set Importer started...','startup');
+        $startTime = microtime(true);
+        
+        // perform attribute import (if enabled)
+        if($this->getParam('5B5ATI:enable','on')=='on') {
+            $csvreader = $this->prepareCSV('5B5ATI');
+            $this->importAttributes($csvreader);
+            $csvreader->closeCSV();
+            unset($csvreader);
+        }
+        
+        // perform attribute set import (if enabled)
+        if($this->getParam('5B5ASI:enable','on')=='on') {
+            $csvreader = $this->prepareCSV('5B5ASI');
+            $this->importAttributeSets($csvreader);
+            $csvreader->closeCSV();
+            unset($csvreader);
+        }
+        
+        // perform attribute associations import (if enabled)
+        if($this->getParam('5B5AAI:enable','on')=='on') {
+            $csvreader = $this->prepareCSV('5B5AAI');
+            $this->importAttributeAssociations($csvreader);
+            $csvreader->closeCSV();
+            unset($myreader);
+            unset($csvreader);
+        }
+        
+        // and that's it!
+        $timediff = microtime(true) - $startTime;
+        $this->log("Attribute Set Importer finished after $timediff seconds.",'startup');
+        
+    }
+    
+    /**
+     * <p>Fetches data from given table returning an associative MultiDimArray which uses the values of the columns given in  $nameColumnNames as keys
+     * and the value from $idColumnName as values.</p>
+     * @param string $tableName name of the table to fetch data from (without table prefix)
+     * @param string $idColumnName name of table column to use as values for resulting array
+     * @param array $nameColumnNames names of columns to use as keys for resulting array
+     * @param array $conditions associative array defining conditions key is the column name, value the condition value (SQL: ... WHERE $key = $value... ) 
+     */
+    public function fetchName2Ids($tableName,$idColumnName,$nameColumnNames,$conditions) {
+        
+        // prepare array names $allColumns with all coumns to fetch from database
+        $allColumns = $nameColumnNames;
+        array_unshift($allColumns,$idColumnName);
+        
+        // fetch data
+        $data = $this->fetch ($tableName,$allColumns,$conditions);
+
+        // prepare resulting array
+        // MutliDimArray to store result
+        $resultByName = new MultiDimArray();
+        foreach($data as $item) {
+            $names = array();
+            foreach($nameColumnNames as $nameColumn) {
+                $names[] = $item[$nameColumn];
+            }
+            $resultByName[$names] = $item[$idColumnName];
+        }
+        unset($data);
+        return $resultByName;
+    }
+    
+    /**
+     * <p>Executes a select which could be described with the following preudo SQL:<br/>
+     * <code>SELECT $columns FROM $tableName WHERE [for each entry in $conditions:] $key = $value</code><br/>
+     * and returns the result.</p>
+     * @param string $tableName name of the table to fetch data from. (without table prefix)
+     * @param array $columns names of the table columns to fetch.
+     * @param array $conditions associative array defining conditions key is the column name, value the condition value (SQL: ... WHERE $key = $value... ) 
+     */
+    private function fetch($tableName,$columns,$conditions) {
+        $sql = "SELECT ".(isset($columns)?implode(',',$columns):"*")." FROM ".$this->tablename($tableName);
+        $values = array();
+        if(isset($conditions) && sizeof($conditions) > 0) {
+            $stringConditions = array();
+            foreach($conditions as $fieldName => $value) {
+                $stringConditions[] = "$fieldName = ?";
+                $values[] = $value;
+            }
+            $sql .= " WHERE ".implode(" AND ",$stringConditions);
+        }
+        $data = $this->selectAll($sql,$values);
+        return $data;
+    }
+
+    /**
+     * <p>Fetches data from given tables returning an associative MultiDimArray which uses the values of the columns given in $nameColumnNames as keys
+     * and an associative array (column name => column value) with merged data from all tables as values.</p>
+     * <p><b>The first table must own all columns given in $nameColNames, all given tables must share the same $idColName. Columns used in conditions MUST also belong to first tableå!å</b></p>
+     * @param array $tables names of the tables to fetch data from (without table prefix)
+     * @param string $idColumnName name of table column of the primary key column (in ALL tables!)
+     * @param array $nameColumnNames names of columns to use as keys for resulting array (all of which must belong to first table)
+     * @param array $conditions associative array defining conditions key is the column name, value the condition value (SQL: ... WHERE $key = $value... ). All used columns MUST belong to first table!
+     */ 
+    private function fetchGeneric($tables,$idColName,$nameColNames,$conditions) {
+        $resultByNames = new MultiDimArray();
+        $namesById = array();
+        $isFirstTable = true;
+        foreach($tables as $tableName) {
+            $columnNames = $this->cols($tableName);
+            $data = $this->fetch($tableName,null,($isFirstTable?$conditions:array()));
+            foreach($data as $item) {
+                $id = $item[$idColName];
+                if($isFirstTable) {
+                    $names = array();
+                    foreach($nameColNames as $nameColName) $names[] = $item[$nameColName];
+                    $namesById[$id] = $names;
+                    $resultByNames[$names] = $item;
+                } else {
+                    if(isset($namesById[$id])) {
+                        $names = $namesById[$id];
+                        foreach($item as $columnName => $value) {
+                            $storedItem = $resultByNames[$names];
+                            $storedItem[$columnName] = $value;
+                            $resultByNames[$names] = $storedItem;
+                        }
+                    }
+                }
+            }
+            unset($data);
+            $isFirstTable=false;
+        }
+        unset($namesById);
+        return $resultByNames;
+    }
+    
+    /**
+     * <p>Uses data given via a CSVReader or another class implementing getLinesCount(), getColumnNames() and getNextRecord() to update / insert / delete / and prune
+     * data into/from table(s) given in $config, according to the configured plugin options.</p>
+     * 
+     * <p>Generally, this is done in the following steps:
+     * <ol>
+     * <li>Fetch already existing data from database table(s) (see fetchGeneric()) into an associative array having the records "names" as key. (see section "names concept" below)</li>
+     * <li>Update/Insert Loop<br/>
+     *     This loop iterates over the given records (from CSV file) and searches its counterpart in DB data
+     *     <ol>
+     *     <li>if magmi:delete flag is set in CSV record (and option "PREFIX:magmi_delete" is active) -> delete record in DB (if it exists)</li>
+     *     <li>if record does not exist in DB right now -> create it (if option "PREFIX:create" is active)</li>
+     *     <li>if record is already existing in DB -> compare contents of records and update if necessary (if option "PREFIX:udpate" is active)</li>
+     *     <li>meanwhile store the identifying columns ("names") of all given records (except deleted ones) as keys of a MultiDimArray for faster acces in second
+     *           (prune) loop. ($givenNameValues)</li>
+     *     </ol></li>
+     * <li>Prune Loop (if option "PREFIX:prune" is switched on)<br/>
+     *     This loop iterates over the given records from DATABASE and checks, if the same record (with the same name(s)) has been given by datasource in this update
+     *     <ol>
+     *     <li>if the DB record's 'names' are not in $givenNameValues, the record will be deleted, except
+     *         <ol>
+     *         <li>the names are given partly or fully (see below) in option "PREFIX:prune_keep" or</li>
+     *         <li>option "PREFIX:prune_keep_system_attributes" is enabled and the records ID was found among the ids returned by the $fetchSystemAttributeIdsSql statement.</li>
+     *         </ol></li>
+     *     </ol></li>
+     * <li>DONE!</li>
+     * </ol></p>
+     * 
+     * <h3>The "names" concept:</h3>
+     * <p>As records in import files are normally given without a primary key database id (and even cannot be given with an id if the record is new ;) ) there
+     * must be some sort of concept to identify, which record in import data corresponds to which record in the database table.
+     * In some cases this is quite easy: The attribute_code column identifies an attribute, the attribute_set_name column identifies an attribute set.
+     * In some cases it is more difficult: An attribute group still can be identified by a single column (attribute_group_name) but only within one single attribute set!
+     * But an attribute association can only be identified by three columns ('attribute_set_id','attribute_id' and 'attribute_group_id') if you don't know the 'entity_attribute_id'.
+     * Therefore the records are matched between import datasource and database using a "names array" which holds the values of all identifying fields (in most cases just one but sometimes three).</p>
+     * 
+     * <h3>The $config parameter</h3>
+     * <p>The $config parameter is an associative array which contains most options needed for this function:
+     * <ul>
+     * <li><b>entityName</b> (string): The name of the current entity type (e.g. "attribute set") to print in log statements and error messages.</li>
+     * <li><b>tables</b> (indexed array): List of tables to update/insert into/delete from etc. All given tables must share the same id column (idColName). The table with the name column must be given as first element.</li>
+     * <li><b>idColName</b> (string): Name of the primary key column (must be the same for ALL given tables)</li>
+     * <li><b>nameColNames</b> (indexed array): List of identifying name columns (see "name concept"). All name columns must be in FIRST TABLE.</li>
+     * <li><b>elementPrefix</b> (string): Prefix of plugin config parameter names (without ':').</li>
+     * <li><b>verbose</b> (boolean): If true, logs status messages to startup log.</li>
+     * <li><b>fetchSystemAttributeIdsSql</b> (string): Sql statement that returns the primary key ids of those elements, which should be kept if option "PREFIX:prune_keep_system_attributes is switched on. (write table names as "##tablename##" to apply table prefix if configured.)
+     * </ul>
+     * @param Magmi_CSVReader $csvreader a Magmi_CSVReader or an instance of any other class implementing the functions getLinesCount(), getColumnNames() and getNextRecord(). This object provides the data which should be imported.
+     * @param array $config config in form of an associative array, see above!
+     * @param array $defaults associative array, keys are the column names, values are the default values for the resprective field/column. Default values will be applied to each record from $csvreader if there is no value for the respective column.
+     * @param array $fetchConditions same format as $defaults, only that the values are used as condition when fetching existing data from the database
+     * @param Name2IdDecoder $decoder instance of Name2IdDecoder, that decodes all given names into ids before data is handled, may be null for "no decoding", necessary when names have to fetched from different tables to process.
+     * @return Statistics object containing the amounts of updated/inserted/deleted... records.
+     */
+    private function updateGeneric($csvreader,$config,$defaults,$fetchConditions,$decoder=null) {
+        // extract the following variables from $config:
+        // entityName,tables,idColName,nameColNames,elementPrefix,verbose,fetchSystemAttributeIdsSql
+        extract($config);
+        
+        //is this an attribute set import? -> this flag triggers attribute set group update later on
+        $isASImport = $elementPrefix == '5B5ASI';
+        
+        $givenRecordCount = $csvreader->getLinesCount();
+        if($verbose) $this->log("Will update ${entityName}s...($givenRecordCount records given)",'startup');
+        
+        // fetch data from database: result is a MultiDimArray with the record "names" as key(s)
+        $dbDataByName = $this->fetchGeneric($tables,$idColName,$nameColNames,$fetchConditions); // fetch attribute sets from db
+        $dbRecordCount = sizeof($dbDataByName);
+        if($verbose) $this->log("Fetched $dbRecordCount existing ".$entityName."s.",'startup');
+
+        // merge default values into $mergedDefaults, defaults are given from two sources: from user config parameter PREFIX:default_values (in JSON format)
+        // and from function parameter $defaults
+        $mergedDefaults = [];
+        $paramDefaults = json_decode($this->getParam($elementPrefix.":default_values","{}"),true);
+        if(isset($defaults) || isset($paramDefaults)) {
+            $mergedDefaults = array_merge((array)$paramDefaults,(array)$defaults);
+        }
+        
+        /* ----------------------------------------------------------------------------------------------------------------------------------------------------------------
+        *  Insert/update loop
+        *  ---------------------------------------------------------------------------------------------------------------------------------------------------------------- */
+        $statistics = new Statistics(); // keeps statistics information
+        $groupStatistics = new Statistics(); // accumulates statistics information for all attribute set group updates (only attribute set import)
+        $lastReportTime = time(); // initialize report time -> to be able to report progress every second
+        $currentRecordNo = 0; // just for counting...
+        $givenNameValues = new MultiDimArray(); // store given Attribute names for faster pruning in second loop
+        
+        // iterate over all given records from CSV
+        while($record = $csvreader->getNextRecord()) {
+            try {
+                // counters and helper variables for statistics
+                // (using booleans for statistics to only count one record once in multi-table updates (having more than one
+                // table configured in $tables)
+                $currentRecordNo++;
+                $updatedRecord = false;
+                $deletedRecord = false;
+                $insertedRecord = false;
+                $nothingToUpdateRecord = false;
+                $doubledRecord = false;
+                
+                // apply default values to current record
+                foreach($mergedDefaults as $key => $value) {
+                    // don't overwrite, only set if not previously given
+                    if(!isset($record[$key])) {
+                        $record[$key] = $value;
+                    }
+                }
+                
+                // if a decoder is given, decode given names to corresponding ids first
+                // default values are given as names so this must be done AFTER defaults are applied,
+                // otherwise defaults would have to be given as ids.
+                if(isset($decoder)) {
+                    $record = $decoder->decode($record);
+                }
+                
+                // prepare the $currentNames array -> this array contains the record's "name" value(s)
+                $currentNames = array();
+                foreach($nameColNames as $nameColName) $currentNames[] = $record[$nameColName];
+                
+                // was a record with same "names" already given?
+                // if yes -> log the names to simplify searching doubled entries or errors in CSV generation
+                // (logged to php error_log to avoid spamming the normal "startup" log entries)
+                if(isset($givenNameValues[$currentNames])) {
+                    error_log("Doubled record: ". print_r($currentNames,true));
+                    $doubledRecord = true; // just for statistics to inform user
+                }
+                
+                // if magmi_delete option is set and current record has magmi:delete set to 1 delete record from database
+                if($this->getParam($elementPrefix.":magmi_delete","off")=="on" && isset($record['magmi:delete']) && $record['magmi:delete'] == 1) {
+                    
+                    // record existing in database?
+                    $dbRecord = $dbDataByName[$currentNames];
+                    if(isset($dbRecord)) {
+                        // yes .. delete it (in all tables from $tables)!
+                        foreach($tables as $tableName) {
+                            $columnNames = $this->cols($tableName);
+                            $sql = "DELETE FROM ".$this->tablename($tableName)." WHERE $idColName=?";
+                            $values = array($dbRecord[$idColName]);
+                            $this->delete($sql,$values);
+                            $deletedRecord=true;
+                        }
+                    }
+                } else {
+                    // found a record (which will not be deleted) so add it to the $givenNameValues
+                    $givenNameValues[$currentNames] = 1;
+                    
+                    // names existing in database? -> if yes this is an update else an insert
+                    if(!isset($dbDataByName[$currentNames])) {
+                        // record not existing yet, is create option enabled?
+                        if($this->getParam($elementPrefix.":create",'on')=='on') {
+                            
+                            // create option is enabled, so create the record in each table from $tables
+                            foreach($tables as $tableName) {
+                                $columnNames = $this->cols($tableName);
+                                $usedColumnNames = array();
+                                $usedValues = array();
+                                $questionMarks = array();
+                                foreach($columnNames as $columnName) {
+                                    if(isset($record[$columnName])) {
+                                        $usedColumnNames[] = $columnName;
+                                        $usedValues[] = $record[$columnName];
+                                        $questionMarks[] = "?";
+                                    }
+                                }
+                                
+                                // store database ID of created record (if there are more than one table in $tables, the id is needed for further tables)
+                                // therefore the "main" table must always be the FIRST one in $tables
+                                $newId = $this->insert("INSERT INTO ".$this->tablename($tableName)." (".implode(",",$usedColumnNames).") VALUES (".implode(",",$questionMarks).")",$usedValues);
+                                $insertedRecord=true;
+                                // is there already a database id set in $record ? If no, store it in $record right now.
+                                if(!isset($record[$idColName])) {
+                                    $record[$idColName] = $newId;
+                                }
+                            }
+
+                            // if this is an attribute set import (and record has a "magmi:groups" value),
+                            // also update the groups of the current set based on the values given in "magmi:groups" and "magmi:default_group"
+                            if($isASImport && isset($record['magmi:groups'])) {
+                                $result = $this->updateAttributeSetGroups($record[$idColName],$record['magmi:groups'],isset($record['magmi:default_group'])?$record['magmi:default_group']:null);
+                                $groupStatistics->add($result);
+                            }
+                        }
+                    } else {
+                        // record is already existing in database.. this is an update
+                        // is update option enabled?
+                        if($this->getParam($elementPrefix.":update",'on')=='on') {
+                            // get database id of existing database record
+                            $id = $dbDataByName[$currentNames][$idColName];
+                            // now update all tables from $tables
+                            foreach($tables as $tableName) {
+                                $columnNames = $this->cols($tableName);
+                                
+                                // put together values and set for current table
+                                // (only with changed columns)
+                                $setClauses = array();
+                                $usedValues = array();
+                                foreach($columnNames as $columnName) {
+                                    if(isset($record[$columnName]) && $record[$columnName] != $dbDataByName[$currentNames][$columnName]) {
+                                        $setClauses[] = $columnName." = ?";
+                                        $usedValues[] = $record[$columnName];
+                                    }
+                                }
+                                
+                                // is there at least one setClause (has at least one column changed?)
+                                // -> then update!
+                                if(sizeof($setClauses) > 0) {
+                                    $usedValues[] = $id;
+                                    $sql = "UPDATE ".$this->tablename($tableName)." SET ".implode(",",$setClauses)." WHERE $idColName = ?";
+                                    $this->update($sql,$usedValues);
+                                    $updatedRecord=true;
+                                } else {
+                                    $nothingToUpdateRecord=true;
+                                }
+                            }
+                            
+                            // if this is an attribute set import (and record has a "magmi:groups" value),
+                            // also update the groups of the current set based on the values given in "magmi:groups" and "magmi:default_group"
+                            if($isASImport && isset($record['magmi:groups'])) {
+                                $result = $this->updateAttributeSetGroups($id,isset($record['magmi:groups'])?$record['magmi:groups']:'',isset($record['magmi:default_group'])?$record['magmi:default_group']:null);
+                                $groupStatistics->add($result);
+                            }
+                        }
+                    }
+                }
+                
+                // now update statistics values
+                if($insertedRecord) $statistics->inserted++;
+                if($deletedRecord) $statistics->deleted++;
+                if($doubledRecord) $statistics->doubled++;
+
+                // only increase nothingToUpdate if no $updateRecord is not set
+                // (which means for multi-table updates none of the tables has been updated)
+                if($updatedRecord) $statistics->updated++;
+                else if($nothingToUpdateRecord) $statistics->nothingToUpdate++;
+
+                // if there is a time() difference between now and $lastReportTime (which means
+                // $lastReportTime was at least one second ago (because time() uses seconds))
+                // then output the progress
+                if(time()-$lastReportTime != 0 || $currentRecordNo == $givenRecordCount) {
+                    $lastReportTime = time();
+                    if($verbose) $this->log("Insert & Update loop processed $currentRecordNo/$givenRecordCount records.",'startup');
+                }
+            } catch(Exception $e) {
+                // exception within loop -> log Exception
+                $this->log("Exception in update/insert loop for entity '$entityName' in record no $currentRecordNo: ".$e->getMessage()."\nrecord data:".print_r($record,true)."\nsee trace log!",'startup');
+                $this->trace($e,"Exception in update/insert loop for entity '$entityName' in record no $currentRecordNo: ".$e->getMessage()."\nrecord data:".print_r($record,true));
+            }
+        }
+        
+        
+        /* ----------------------------------------------------------------------------------------------------------------------------------------------------------------
+         *  Prune loop
+         *  ---------------------------------------------------------------------------------------------------------------------------------------------------------------- */
+        
+        // is prune option switched on?
+        if($this->getParam($elementPrefix.":prune","on")=="on") {
+            
+            // parse option "PREFIX:prune_keep".
+            // For entities identified by a single name this is easy: The names to keep are given in a simple comma-separated list.
+            // For entities identified by more than one name/column, it is more complex:
+            // * Either a comma-separated list is given, which means, only the first "name" will be compared, and if it matches
+            //   the record will be kept
+            //   for attribute set associations (which uses mor than one name) this will translate to
+            //   "keep all associations for attribute sets with given names", because order of nameColNames is ['attribute_set_id','attribute_id','attribute_group_id']
+            //   -> attribute_set_name is first!
+            // * or a JSON Array (in fact an array of arrays) is given, which allows to give mor than one name per entry
+            //   e.g. if for attribute associations the following array would be given:
+            //     [["Default"],["Set1","name"],["Set2","name","Group1"]]
+            //     this could be translated to keep all associations for set "Default", keep all associations for attribute "name" in "Set1" (regardless of group)
+            //     and keep association for attribute "name" in "Set2" if it is in group "Group1"
+            
+            // fetch value from option "PREFIX:prune_keep
+            $keepNamesString = trim($this->getParam($elementPrefix.":prune_keep",""));
+            // if value starts with a '[' this is a JSON array...
+            if(substr($keepNamesString, 0, 1) == '[') {
+                $keepNames = json_decode($keepNamesString);
+            } else {
+                // "normal" comma-separated string: transform to same
+                // format than it would be converted from JSON: array of arrays
+                $keepNames = array();
+                foreach(explode(",",$keepNamesString) as $part) {
+                    $keepNames[] = array(trim($part));
+                }
+            }
+            
+            // now set all elements of given array of arrays (-> each single array entry)
+            // in a new MultiDimArray to 1 for easy and fast comparison
+            // see documentation of "multiSet" and "offsetExistsPartly" functions of MultiDimArray
+            $keepNamesArray = new MultiDimArray();
+            $keepNamesArray->multiSet($keepNames,1);
+
+            // if there is a name to id $decoder set
+            // decode the keys of the $keepNamesArray to the respective database ids
+            if(isset($decoder)) {
+                $newKeepNamesArray = new MultiDimArray();
+                
+                // iterate over all array keys of MultiDimArray
+                // (using rewind(), valid(), next() offsetSet() because the short notation and foreach do not like array indexes)
+                $keepNamesArray->rewind();
+                while($keepNamesArray->valid()) {
+                    $entry = $keepNamesArray->key();                    
+                    $newKeepNamesArray->offsetSet($decoder->decode($entry),1);
+                    $keepNamesArray->next();
+                }
+                $keepNamesArray = $newKeepNamesArray;
+            }
+            
+
+            // prepare array with database ids as keys for entries which should not be pruned as the elements are related to system attributes
+            $keepSystemIds = array();
+            if($this->getParam($elementPrefix.":prune_keep_system_attributes","off") == "on")
+            {
+                $sql = preg_replace_callback('/(##[a-zA-Z_]*##)/Uis',function($ms){foreach($ms as $m){return str_replace('##','',$this->tablename($m));}},$fetchSystemAttributeIdsSql);
+                $idData = $this->select($sql);
+                foreach($idData as $record) {
+                    $keepSystemIds[reset($record)] = 1;
+                }
+            }
+            
+            // just for counting records...
+            $currentRecordNo = 0;
+            
+            // now loop aver all records from database...
+            // again use rewind(), valid(), next() and offsetSet() because the short notation and foreach do not like array indexe
+            $dbDataByName->rewind();
+            while($dbDataByName->valid()) {
+                try {
+                    $currentRecordNo++;
+                    $currentNames = $dbDataByName->key();
+                    $dbRecord = $dbDataByName->current();
+                    // database id of current record
+                    $currentId = $dbRecord[$idColName];
+                    
+                    // statistics flags
+                    $prunedRecord = false;
+                    $keptRecord = false;
+
+                    // check if conditions for pruning are matched (see above,1.) except a.) and b.) )
+                    if(!$givenNameValues->offsetExists($currentNames) && !$keepNamesArray->offsetExistsPartly($currentNames) && !isset($keepSystemIds[$currentId])) {
+                        // delete in each configured table
+                        foreach($tables as $tableName) {
+                            $columnNames = $this->cols($tableName);
+                            $sql = "DELETE FROM ".$this->tablename($tableName)." WHERE $idColName=?";
+                            $this->delete($sql,array($currentId));
+                            $prunedRecord=true;
+                        }
+                    } else {
+                        $keptRecord=true;
+                    }
+                    
+                    // update statistics
+                    if($prunedRecord) $statistics->pruned++;
+                    else if ($keptRecord) $statistics->kept++;
+                    
+                    // again, if there is a time() difference between now and $lastReportTime (which means
+                    // $lastReportTime was at least one second ago (because time() uses seconds))
+                    // then output the progress
+                    if(time()-$lastReportTime != 0 || $currentRecordNo == $dbRecordCount) {
+                        $lastReportTime = time();
+                        if($verbose) $this->log("Prune loop processed $currentRecordNo/$dbRecordCount records.",'startup');
+                    }
+                } catch(Exception $e) {
+                    // exception within loop -> log Exception
+                    $this->log("Exception in prune loop for entity '$entityName' in record no $currentRecordNo: ".$e->getMessage()."\nrecord data:".print_r($dbRecord,true)."\nsee trace log!",'startup');
+                    $this->trace($e,"Exception in prune loop for entity '$entityName' in record no $currentRecordNo: ".$e->getMessage()."\nrecord data:".print_r($dbRecord,true));
+                }
+                $dbDataByName->next();
+            }
+        }
+        if($verbose) $this->log("Finished updating ".$entityName."s: $statistics",'startup');
+        if($verbose && $isASImport) $this->log("Groups: $groupStatistics",'startup');
+        return $statistics;
+    }
+    
+    /**
+     * <p>Updates 
+     * @param integer $asId attribute_set_id of attribute set to update groups for
+     * @param string $groupString string containing group names and sort orders in format: "<groupname>[:<sortorder>],<groupname>[:<sortorder>],<groupname>[:<sortorder>],..." where <groupname> is a string and <sortorder> an integer, if sortorders are not given, the order number is increased by 1 for each entry
+     * @param string $defaultGroup name of the default group, defaults to "General"
+     */
+    private function updateAttributeSetGroups($asId,$groupString,$defaultGroup="General") {
+        $asgTableName = $this->tablename('eav_attribute_group');
+        
+        // givenGroups will be filled with the appropriate values and will later on serve as datasource for the attribute group updateGeneric() call
+        $givenGroups = array();
+        $index = 0;
+        // separate groupString into substrings in format "<groupname>:<sortorder>" and iterate over the results
+        foreach(explode(',',$groupString) as $group) {
+            $groupNameAndSortOrder = explode(':',$group,2);
+            $groupName = trim($groupNameAndSortOrder[0]);
+
+            // sortorder defaults to $index
+            $sortOrder = $index;
+            // if the group string has a sortorder -> use sortorder from string
+            if(isset($groupNameAndSortOrder[1])) {
+                try {
+                    $sortOrder = intval(trim($groupNameAndSortOrder[1]));
+                } catch(Exception $e){}
+            }
+            
+            $isDefault = $groupName == $defaultGroup; 
+            $givenGroups[] = array(
+                    'attribute_group_name' => $groupName,
+                    'sort_order' => $sortOrder,
+                    'default_id' => $isDefault?1:0);
+
+            $index=$sortOrder+1;
+        }
+
+        // prepare ArrayReader out of $givenGroups
+        $datasource = new ArrayReader();
+        $datasource->initialize($givenGroups);
+        
+        // current attribute set id must be set for defaults and fetchConditions we only want to update groups for the current attribute set.
+        $condition = ['attribute_set_id'=>$asId];
+
+        // call updateGeneric with prepared data
+        return $this->updateGeneric($datasource,$this->ATTRIBUTE_GROUP_ARGS,$condition,$condition);
+    }
+
+    public function afterImport()
+    {
+        // intentionally left blank...
+    }
+    
+    /**
+     * Fetches the entity_type_id from database and stores it to $this->_prod_etype
+     */
+    private function fetchProdEType()
+    {
+        if($this->_prod_etype == null) {
+            $tname = $this->tablename("eav_entity_type");
+            $this->_prod_etype = $this->selectone("SELECT entity_type_id FROM $tname WHERE entity_type_code=?",
+                    "catalog_product", "entity_type_id");
+        }
+    }
+    
+    /**
+     * Calls the engine's trace function with the plugin's name and version as a prefix.
+     * @param Exception $e the exception to trace
+     * @param string $message message
+     */
+    public function trace($e,$message="no message") {
+        $pinf = $this->getPluginInfo();
+        $data = "{$pinf["name"]} v{$pinf["version"]} - ".$message;
+        $this->_caller_trace($e,$data);
+    }
+}
+
+/**
+ * <p>Container for statistics data. Keeps track of the amount of updated, inserted, deleted, ... records.</p>
+ */
+class Statistics {
+    public $pruned=0,$kept=0,$inserted=0,$updated=0,$nothingToUpdate=0,$deleted=0,$doubled=0;
+    
+    /**
+     * <p>Adds the calues of another Statistics instance to thie instance's counters.</p>
+     * @param Statistics $otherStatistics Statistics instance with values to add to $this instance's values.
+     */
+    public function add(Statistics $otherStatistics) {
+        $this->pruned+=$otherStatistics->pruned;
+        $this->kept+=$otherStatistics->kept;
+        $this->inserted+=$otherStatistics->inserted;
+        $this->updated+=$otherStatistics->updated;
+        $this->nothingToUpdate+=$otherStatistics->nothingToUpdate;
+        $this->deleted+=$otherStatistics->deleted;
+        $this->doubled+=$otherStatistics->doubled;
+    }
+    
+    /**
+     * <p>Returns a string containing all values for output/logging purposes.</p>
+     * @return string
+     */
+    public function __toString()
+    {
+        return "Deleted: $this->deleted, Updated: $this->updated, Doubled: $this->doubled, Nothing to update: $this->nothingToUpdate, Inserted: $this->inserted, Pruned: $this->pruned, Kept: $this->kept";
+    }
+    
+}

--- a/magmi/plugins/5b5/general/attributesetimport/checkbox.php
+++ b/magmi/plugins/5b5/general/attributesetimport/checkbox.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ * Prints HTML for a checkbox option to the output.
+ * expects:
+ *  $prefix (string): the prefix for options
+ *  $name (string): the option name
+ */
+    $fullName = "$prefix:$name";
+    $currentValue = $self->getParam($fullName,$default)=="on"?"on":"off";
+?>
+<div class="" id="<?php echo $fullName?>">
+	<input type="checkbox" name="<?php echo $fullName?>_cb" id="<?php echo $fullName?>_cb"
+		<?php if($self->getParam($fullName,$default)=="on"){?>
+		checked="checked" <?php }?>> <?php echo $description?>
+	<input type="hidden" id="<?php echo $fullName ?>_hf" name="<?php echo $fullName?>" value="<?php echo $currentValue ?>"/>
+	<script type="text/javascript">
+		$('<?php echo $fullName?>_cb').observe('click',function(){
+			if($('<?php echo $fullName ?>_cb').checked) {
+				$('<?php echo $fullName ?>_hf').value = 'on';
+			} else {
+				$('<?php echo $fullName ?>_hf').value = 'off';
+			}
+		});
+	</script>
+</div>

--- a/magmi/plugins/5b5/general/attributesetimport/csv_options.php
+++ b/magmi/plugins/5b5/general/attributesetimport/csv_options.php
@@ -1,0 +1,114 @@
+<div>
+	<ul class="formline">
+		<li class="label">CSV import mode</li>
+		<li class="value"><select name="<?php echo $prefix ?>:importmode" id="<?php echo $prefix ?>:importmode">
+				<option value="local"
+					<?php if($self->getParam("$prefix:importmode","local")=="local"){?>
+					selected="selected" <?php }?>>Local</option>
+				<option value="remote"
+					<?php if($self->getParam("$prefix:importmode","local")=="remote"){?>
+					selected="selected" <?php }?>>Remote</option>
+		</select>
+	
+	</ul>
+
+	<div id="<?php echo $prefix ?>:localcsv"
+		<?php if($self->getParam("$prefix:importmode","local")=="remote"){?>
+		style="display: none" <?php }?>>
+		<ul class="formline">
+			<li class="label">CSVs base directory</li>
+			<li class="value"><input type="text" name="<?php echo $prefix ?>:basedir"
+				id="<?php echo $prefix ?>:basedir"
+				value="<?php echo $self->getParam("$prefix:basedir","var/import")?>"></input>
+				<div class="fieldinfo">Relative paths are relative to magento base
+					directory , absolute paths will be used as is</div></li>
+		</ul>
+		<ul class="formline">
+			<li class="label">File to import:</li>
+			<li class="value" id="<?php echo $prefix ?>:csvds_filelist">
+ <?php require('csvds_filelist.php'); ?>
+ </li>
+		</ul>
+	</div>
+
+	<div id="<?php echo $prefix ?>:remotecsv"
+		<?php if($self->getParam("$prefix:importmode","local")=="local"){?>
+		style="display: none" <?php }?>>
+		<ul class="formline">
+			<li class="label">Remote CSV url</li>
+			<li class="value"><input type="text" name="<?php echo $prefix ?>:remoteurl"
+				id="<?php echo $prefix ?>:remoteurl"
+				value="<?php echo $self->getParam("$prefix:remoteurl","")?>"
+				style="width: 400px"></input> <input type="checkbox"
+				id="<?php echo $prefix ?>:forcedl" name="<?php echo $prefix ?>:forcedl"
+				<?php if($self->getParam("$prefix:forcedl",false)==true){?>
+				checked="checked" <?php }?>>Force Download</li>
+		</ul>
+
+		<div id="<?php echo $prefix ?>:remotecookie">
+			<ul class="formline">
+				<li class="label">HTTP Cookie</li>
+				<li class="value"><input type="text" name="<?php echo $prefix ?>:remotecookie"
+					id="<?php echo $prefix ?>:remotecookie"
+					value="<?php echo $self->getParam("$prefix:remotecookie","")?>"
+					style="width: 400px"></li>
+			</ul>
+		</div>
+		<input type="checkbox" id="<?php echo $prefix ?>:remoteauth" name="<?php echo $prefix ?>:remoteauth"
+			<?php  if($self->getParam("$prefix:remoteauth",false)==true){?>
+			checked="checked" <?php }?>>authentication needed
+		<div id="<?php echo $prefix ?>:remoteauth"
+			<?php  if($self->getParam("$prefix:remoteauth",false)==false){?>
+			style="display: none" <?php }?>>
+			<div class="remoteuserpass">
+				<ul class="formline">
+					<li class="label">User</li>
+					<li class="value"><input type="text" name="<?php echo $prefix ?>:remoteuser"
+						id="<?php echo $prefix ?>:remoteuser"
+						value="<?php echo $self->getParam("$prefix:remoteuser","")?>"></li>
+
+				</ul>
+				<ul class="formline">
+					<li class="label">Password</li>
+					<li class="value"><input type="text" name="<?php echo $prefix ?>:remotepass"
+						id="<?php echo $prefix ?>:remotepass"
+						value="<?php echo $self->getParam("$prefix:remotepass","")?>"></li>
+				</ul>
+			</div>
+
+		</div>
+
+	</div>
+
+
+</div>
+<div>
+	<h4>CSV options</h4>
+	<span class="">CSV separator:</span><input type="text" maxlength="3"
+		size="3" name="<?php echo $prefix ?>:separator"
+		value="<?php echo $self->getParam("$prefix:separator")?>"></input> <span
+		class="">CSV Enclosure:</span><input type="text" maxlength="3"
+		size="3" name="<?php echo $prefix ?>:enclosure"
+		value='<?php echo $self->getParam("$prefix:enclosure")?>'></input>
+</div>
+
+<div class="">
+	<input type="checkbox" name="<?php echo $prefix ?>:allowtrunc"
+		<?php if($self->getParam("$prefix:allowtrunc",false)==true){?>
+		checked="checked" <?php }?>> Allow truncated lines (bypasses data line
+	structure correlation with headers)
+</div>
+
+<?php
+
+$hdline = $self->getParam("<?php echo $prefix ?>:headerline", "");
+$malformed = ($hdline != "" && $hdline != 1)?>
+<input type="checkbox" id="<?php echo $prefix ?>:malformed_cb" <?php if($malformed){?>
+	checked="checked" <?php }?> />
+Malformed CSV (column list line not at top of file)
+<div id="<?php echo $prefix ?>:malformed" <?php if(!$malformed){?> style="display: none"
+	<?php }?>>
+	<span class="">CSV Header at line:</span><input type="text"
+		id="<?php echo $prefix ?>:headerline" name="<?php echo $prefix ?>:headerline" maxlength="7" size="7"
+		value="<?php echo $hdline?>"></input>
+</div>

--- a/magmi/plugins/5b5/general/attributesetimport/csvds_filelist.php
+++ b/magmi/plugins/5b5/general/attributesetimport/csvds_filelist.php
@@ -1,0 +1,22 @@
+<?php
+$files = $self->getCSVList($prefix);
+if ($files !== false && count($files) > 0)
+{
+    ?>
+<select name="<?php echo $prefix ?>:filename" id="<?php echo $prefix ?>:csvfile">
+	<?php foreach($files as $fname){ ?>	
+		<option <?php if($fname==$self->getParam("$prefix:filename")){?>
+		selected=selected <?php }?> value="<?php echo $fname?>"><?php echo basename($fname)?></option>
+	<?php }?>
+</select>
+<a id='<?php echo $prefix ?>:csvdl'
+	href="./download_file.php?file=<?php $self->getParam("$prefix:filename")?>">Download
+	CSV</a>
+<script type="text/javascript">
+ $('<?php echo $prefix ?>:csvdl').observe('click',function(el){
+	    var fval=$('<?php echo $prefix ?>:csvfile').value;
+ 		$('<?php echo $prefix ?>:csvdl').href="./download_file.php?file="+fval;}
+	);
+</script><?php } else {?>
+<span> No csv files found in <?php echo $self->getScanDir(false)?></span>
+<?php }?>

--- a/magmi/plugins/5b5/general/attributesetimport/javascript.php
+++ b/magmi/plugins/5b5/general/attributesetimport/javascript.php
@@ -1,0 +1,87 @@
+<script type="text/javascript">
+<?php if($withCsvOptions) { ?>
+handle_auth=function()
+	{
+		if($('<?php echo $prefix ?>:remoteauth').checked)
+		{
+			$('<?php echo $prefix ?>:remoteauth').show();	
+		}
+		else
+		{
+			$('<?php echo $prefix ?>:remoteauth').hide();
+		}
+	}
+
+	$('<?php echo $prefix ?>:basedir').observe('blur',function()
+			{
+			new Ajax.Updater('<?php echo $prefix ?>:csvds_filelist','ajax_pluginconf.php',{
+			parameters:{file:'csvds_filelist.php',
+						plugintype:'datasources',
+					    pluginclass:'<?php echo get_class($plugin)?>',
+					    profile:'<?php echo $self->getConfig()->getProfile()?>',
+					    '<?php echo $prefix ?>:basedir':$F('<?php echo $prefix ?>:basedir')}});
+			});
+	$('<?php echo $prefix ?>:malformed_cb').observe('click',function(ev){
+		if($('<?php echo $prefix ?>:malformed_cb').checked)
+		{
+			$('<?php echo $prefix ?>:malformed').show();	
+		}
+		else
+		{
+			$('<?php echo $prefix ?>:malformed').hide();
+		}
+	});
+	$('<?php echo $prefix ?>:headerline').observe('blur',function()
+	{
+		var wellformed=($F('<?php echo $prefix ?>:headerline')=="1" || $F('<?php echo $prefix ?>:headerline')=="");
+		if(wellformed)
+		{
+			$('<?php echo $prefix ?>:malformed_cb').checked=false;
+			$('<?php echo $prefix ?>:malformed').hide();
+			$('<?php echo $prefix ?>:headerline').value="";
+		}
+	});
+	$('<?php echo $prefix ?>:importmode').observe('change',function()
+			{
+				if($F('<?php echo $prefix ?>:importmode')=='local')
+				{
+					$('<?php echo $prefix ?>:localcsv').show();
+					$('<?php echo $prefix ?>:remotecsv').hide();
+				}
+				else
+				{
+					$('<?php echo $prefix ?>:localcsv').hide();
+					$('<?php echo $prefix ?>:remotecsv').show();
+				}
+			});
+	$('<?php echo $prefix ?>:remoteauth').observe('click',handle_auth);
+	$('<?php echo $prefix ?>:remoteurl').observe('blur',handle_auth);
+<?php } ?>
+	
+	$('<?php echo $prefix ?>:prune_cb').observe('click',function() {
+		if($('<?php echo $prefix ?>:prune_cb').checked)
+			$('<?php echo $prefix ?>:prune_opts').show();
+		else
+			$('<?php echo $prefix ?>:prune_opts').hide();
+	});
+	if($('<?php echo $prefix ?>:enable')) {
+    	$('<?php echo $prefix ?>:enable').observe('click',function() {
+    		if($('<?php echo $prefix ?>:enable_cb').checked) {
+    			$('<?php echo $prefix ?>:enabled').show();
+    		} else {
+    			$('<?php echo $prefix ?>:enabled').hide();
+    		}
+    	});
+	}
+<?php if($prefix == '5B5ASI') { ?>
+	showHideAttributeGroups = function() {
+		if($('<?php echo $prefix ?>:create_cb').checked || $('<?php echo $prefix ?>:update_cb').checked) {
+			$('<?php echo $prefix ?>:attribute_groups').show();
+		} else {
+			$('<?php echo $prefix ?>:attribute_groups').hide();
+		}
+	};
+	$('<?php echo $prefix ?>:create_cb').observe('click',showHideAttributeGroups);
+	$('<?php echo $prefix ?>:update_cb').observe('click',showHideAttributeGroups);
+<?php } ?>	
+</script>

--- a/magmi/plugins/5b5/general/attributesetimport/multi_dim_array.php
+++ b/magmi/plugins/5b5/general/attributesetimport/multi_dim_array.php
@@ -1,0 +1,232 @@
+<?php
+/**
+ * <p>An array class which allows to use (one-dimensional, primitive-type arrays) as keys.<p>
+ * <p>Acts very much like you would expect (in most cases ):
+ * <code><br/>
+ * $mda = new MultiDimArray();<br/>
+ * <br/>
+ * // Setting values:<br/>
+ * $mda->offsetSet(array(1,2,3),"Test");<br/>
+ * $mda->offsetSet(array(3,2),"Test2");<br/>
+ * $mda[array(1,2,3)] = "Test" DOES NOT WORK because arrays are not allowed as index in this notation :(<br/>
+ * <br/>
+ * // Getting values:<br/>
+ * $mda[array(1,2,3)] -> "Test"<br/>
+ * $mda[array(1,2)] -> MultiDimArray() [ 3 => "Test" ]<br/>
+ * $mda[array(1)] -> MultiDimArray() [ 2 => MultiDimArray () [3 => "Test" ]]<br/>
+ * $mda[1] -> MultiDimArray() [ 2 => MultiDimArray () [3 => "Test" ]]<br/>
+ * $mda[1][2][3] -> "Test"<br/>
+ * <br/>
+ * // isset / offsetExists<br/>
+ * isset($mda[array(1,2,3)]) -> true<br/>
+ * isset($mda[array(1,2,3,4)]) -> false<br/>
+ * isset($mda[array(1,2)]) -> true (because $mda[array(1,2)]) also returns a value)<br/>
+ * isset($mda[array(1)]) -> true  (same as above)<br/>
+ * isset($mda[1]) -> true  (see above)
+ * isset($mda[1][2][3]) -> true
+ * isset($mda[array(2)]) -> false (keys are ordered!)<br/>
+ *
+ * $mda->offsetExistsPartly(array(1,2,3,4)) -> true (part of the offset exists)<br/>
+ * $mda->offsetExistsPartly(array(1,2,4)) -> false<br/>
+ * <br/>
+ * // iterating:<br/>
+ * // "foreach" does not allow arrays as keys :(<br/>
+ * $mda->rewind();<br/>
+ * while($mda->valid()) {<br/>
+ *  $key = $mda->key(); // -> 1. iteration: array (1,2,3), 2. iteration: array (3,2)<br/>
+ *  $value = $mda->current(); // -> 1. iteration:"Test", 2. iteration: "Test2"<br/>
+ *  $mda->next();<br/>
+ * }<br/>
+ * </code></p>
+ */
+class MultiDimArray extends ArrayIterator {
+
+    private $_inner;
+    private $_current;
+    private $_currentKey;
+
+    /**
+     * (non-PHPdoc)
+     * @see ArrayIterator::offsetGet()
+     */
+    public function offsetGet($name) {
+        if(!is_array($name)) {
+            return parent::offsetGet($name);
+        } else {
+            $key = array_shift($name);
+            if(!parent::offsetExists($key))
+                return null;
+            $element = parent::offsetGet($key);
+            if(sizeof($name) == 0) {
+                return $element;
+            } else {
+                if(is_a($element,'MultiDimArray')) {
+                    return $element->offsetGet($name);
+                } else {
+                    return $element;
+                }
+            }
+        }
+    }
+
+    /**
+     * (non-PHPdoc)
+     * @see ArrayIterator::offsetSet()
+     */
+    public function offsetSet($name, $value) {
+        if(!is_array($name)) {
+            return parent::offsetSet($name, $value);
+        } else {
+            $key = array_shift($name);
+            if(sizeof($name) == 0) {
+                parent::offsetSet($key, $value);
+            } else {
+                $childArray = parent::offsetExists($key)?parent::offsetGet($key):new MultiDimArray();
+                if(!is_a($childArray,'MultiDimArray')) {
+                    $childArray = new MultiDimArray();
+                }
+                parent::offsetSet($key, $childArray);
+                $childArray->offsetSet($name,$value);
+            }
+        }
+    }
+
+    /**
+     * Returns true, if the given offset exists. Offsets can also be given
+     * partly e.g.:<br/> 
+     * <code>
+     * offsetExists(array(1,2)) will return true, too, if offset array(1,2,3) is set to a value<br/>
+     * but<br/>
+     * offsetExists(array(1,2,3,4)) will return false<br/></code>
+     * (non-PHPdoc)
+     * @see ArrayIterator::offsetExists()
+     */
+    public function offsetExists($name) {
+        return $this->offsetExistsPartly($name,false);
+    }
+
+    /**
+     * If $partlyOk is set to false, works exactly like offsetExists().
+     * If $partlyOk is set to true, it also returns true, if
+     * only a part of the given $name array exists e.g.:<br/>
+     * <code>
+     * offsetExistsPartly(array(1,2,3,4),true) will additionally return true if one of the following offsets exists: array(1), array(1,2), array(1,2,3)<br/></code>
+     * 
+     * @param unknown $name
+     * @param string $partlyOk
+     * @return void|boolean|string
+     */
+    public function offsetExistsPartly($name,$partlyOk=true) {
+        if(!is_array($name)) {
+            return parent::offsetExists($name);
+        } else {
+            $key = array_shift($name);
+            if(sizeof($name) == 0) {
+                return parent::offsetExists($key);
+            } else {
+                if(!parent::offsetExists($key)) {
+                    return false;
+                } else {
+                    $object = parent::offsetGet($key);
+                    if(is_a($object,'MultiDimArray')) {
+                        return $object->offsetExists($name);
+                    } else {
+                        return $partlyOk;
+                    }
+                }
+            }
+        }
+    }
+
+    public function offsetUnset($name) {
+        if(!is_array($name)) {
+            return parent::offsetUnset($name);
+        } else {
+            $key = array_shift($name);
+            if(sizeof($name) == 0) {
+                return parent::offsetUnset($key);
+            } else {
+                if(parent::offsetExists($key)) {
+                    $object = parent::offsetGet($key);
+                    if(is_a($object,'MutliDimArray')) {
+                        $object->offsetUnset($name);
+                        if($object->sizeof()==0) {
+                            parent::offsetUnset($key);
+                        }
+                    } else {
+                        parent::offsetUnset($key);
+                    }
+                }
+            }
+        }
+    }
+
+    public function rewind() {
+        $this->_iterator = null;
+        parent::rewind();
+        $this->setInner();
+    }
+
+    public function current() {
+        if(isset($this->_inner)) {
+            return $this->_inner->current();
+        } else {
+            return parent::current();
+        }
+    }
+
+    private function setInner() {
+        if(parent::valid() && is_a(parent::current(),'MultiDimArray')) {
+            $this->_inner = parent::current();
+            $this->_inner->rewind();
+        }
+    }
+
+    private function doNext() {
+        $this->inner = null;
+        parent::next();
+        $this->setInner();
+    }
+
+    public function next() {
+        if(isset($this->_inner)) {
+            $this->_inner->next();
+            if(!$this->_inner->valid()) {
+                $this->doNext();
+            }
+        } else {
+            $this->doNext();
+        }
+    }
+    public function key() {
+        if(isset($this->_inner)) {
+            $innerKey = $this->_inner->key();
+            array_unshift($innerKey,parent::key());
+            return $innerKey;
+        } else {
+            return array(parent::key());
+        }
+    }
+
+    public function valid() {
+        return parent::valid();
+    }
+
+    public function multiSet($keyArrays, $value) {
+        foreach($keyArrays as $keyArray) {
+            if(is_array($keyArray) && sizeof($keyArray) == 0) {
+                // ignore
+            } else {
+                $this->offsetSet($keyArray,$value);
+            }
+        }
+    }
+    
+    public function count ($mode = null) {
+        $count = 0;
+        foreach($this as $item) $count++;
+        return $count;
+    }
+
+}
+?>

--- a/magmi/plugins/5b5/general/attributesetimport/name2id_decoding.php
+++ b/magmi/plugins/5b5/general/attributesetimport/name2id_decoding.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * <p>Class that takes a number of configurations to replace column values with other values based on a mapping taken from a database table.</p>
+ * <p>e.g. if the following configuration ist given:<br/>
+ * <code>['attr_set_name' => [<br/>
+ *    'tableName' => 'eav_attribute_set',<br/>
+ *    'nameColumnName' => 'attribute_set_name',<br/>
+ *    'idColumnName' => 'attribute_set_id'],<br/>
+ *    'attr_name' => [<br/>
+ *    'tableName' => 'eav_attribute',<br/>
+ *    'nameColumnName' => 'attribute_code',<br/>
+ *    'idColumnName' => 'attribute_id']<br/>
+ * ]<br/></code>
+ * the decoder will remove values for field 'attr_set_name' in given array (function decode) and add a corresponding 'attribute_set_id' taken from table 'eav_attribute_set' by selecting the record having
+ * column 'attribute_set_name' equal to the given 'attr_set_name'. 'attr_name' will be replaced by 'attribute_id's taken from table 'eav_attribute' by mapping 'attr_name' via column 'attribute_code' to an 'attribute_id'.</p>
+ * <p>Therefore the decoder builds up cached mapping tables upon initialization and replaces the record data using the cached data when "decode" is called.</p>
+ * <p>Per configuration one additional id column may be given, which has the effect, that the corresponding record in mapping data will be selected by comparing both the name column and the additional column with the value from the given record.</p>
+ *
+ */
+class Name2IdDecoder {
+    protected $_mappingTables;
+    protected $_mappedColumnNames;
+    protected $_additionalIdColumns;
+
+    /**
+     * <p>Contructs the object instance with the given configuration. (also see class comment!)</p>
+     * @param array $mappings associative array using fieldnames to be replaced as keys having an associative array as value, which has assigned values for 'tableName', 'nameColumnName', 'idColumnName' and, optionally, 'additionalIdColumn'
+     */
+    public function __construct($importer,$mappings) {
+        $this->_mappingTables = array();
+        $this->_mappedColumnNames = array();
+        $this->_additionalIdColumns = array();
+        foreach($mappings as $columnName => $mappingInfo) {
+            $nameColumns = array($mappingInfo['nameColumnName']);
+            if(isset($mappingInfo['additionalIdColumn'])) {
+                array_push($nameColumns, $mappingInfo['additionalIdColumn']);
+            }
+            $this->_mappingTables[$columnName] = $importer->fetchName2Ids($mappingInfo['tableName'],$mappingInfo['idColumnName'],$nameColumns,isset($mappingInfo['conditions'])?$mappingInfo['conditions']:null);
+            $this->_mappedColumnNames[$columnName] = $mappingInfo['idColumnName'];
+            if(isset($mappingInfo['additionalIdColumn'])) {
+                $this->_additionalIdColumns[$columnName] = $mappingInfo['additionalIdColumn'];
+            }
+        }
+    }
+
+    /**
+     * <p>Perform decoding of values in given array.<p>
+     * <p>Returns the mapped record, which means that mapped keys are removed and resulting keys will be added to result. Unmapped keys stay the same and retain their value.</p>
+     * @param unknown $record
+     */
+    public function decode($record) {
+        // is $record an associative or indexed array?
+        $indexed = false;
+        if(!(bool)count(array_filter(array_keys($record), 'is_string'))) {
+            // indexed! -> make associative!
+            $indexed=true;
+            // keys are column names
+            $keys = array_keys($this->_mappedColumnNames);
+            // values is record
+            $values = $record;
+            // make keys and values same size (by cutting off overlapping keys/values)
+            $keys = array_slice($keys, 0,sizeof($values));
+            $values = array_slice($values, 0,sizeof($keys));
+            // make an associative array out of it
+            $record = array_combine($keys,$values);
+        }
+        $indexedResult = array();
+        foreach($this->_mappedColumnNames as $columnName => $idColumnName) {
+            if(isset($record[$columnName])) {
+                $mappingTable = $this->_mappingTables[$columnName];
+                $values = array($record[$columnName]);
+                if(isset($this->_additionalIdColumns[$columnName])) {
+                    $addtnlColumnName = $this->_additionalIdColumns[$columnName];
+                    $addtnlIdValue = $record[$addtnlColumnName];
+                    array_push($values,$addtnlIdValue);
+                }
+                if(isset($mappingTable[$values])) {
+                    $record[$idColumnName] = $mappingTable[$values];
+                    unset($record[$columnName]);
+                    $indexedResult[] = $mappingTable[$values];
+                } else {
+                    $indexedResult[] = $record[$columnName];
+                    error_log("Mapped value not found for column $columnName for name(s): ".print_r($values,true));
+                }
+            }
+        }
+        if($indexed) {
+            // was indexed?? -> return indexed result
+            return $indexedResult;
+        } else {
+            // return associative result
+            return $record;
+        }
+    }
+
+    /** 
+     * Returns the given list of column names, but replacing mapped column names with their corresponding mapping target names.
+     * @return the given list of column names, but replacing mapped column names with their corresponding mapping target names.
+     */
+    public function decodeColumnNames($columnNames) {
+        $newColumnNames = array();
+        foreach($columnNames as $columnName) {
+            if(isset($this->_mappedColumnNames[$columnName])) {
+                $newColumnNames[] = $this->_mappedColumnNames[$columnName];
+            } else {
+                $newColumnNames[] = $columnName;
+            }
+        }
+        return $newColumnNames;
+
+    }
+
+}

--- a/magmi/plugins/5b5/general/attributesetimport/options_panel.php
+++ b/magmi/plugins/5b5/general/attributesetimport/options_panel.php
@@ -1,0 +1,119 @@
+<?php 
+
+    function csvOptions($self,$prefix) {
+        require('csv_options.php');
+    }
+    
+    function checkbox($self,$prefix,$name,$default,$description) {
+        require('checkbox.php');
+    }
+
+    function text($self,$prefix,$name,$default,$description) {
+        require('text.php');
+    }
+    
+    function textarea($self,$prefix,$name,$default,$description) {
+        require('textarea.php');
+    }
+    
+    function javascript($self,$prefix,$withCsvOptions,$plugin) {
+        require('javascript.php');
+    }
+    
+    function startDiv($self,$prefix,$name,$show=true) {
+        $fullName = "$prefix:$name";
+        ?><div id="<?php echo $fullName ?>"<?php if(!$show) {?>style="display:none;"<?php }?>><?php 
+    }
+    function endDiv($self) {
+        ?></div><?php
+    }
+    
+    function options($self,$title,$prefix,$entityName,$withCsvOptions,$withMagmiDelete,$withEnable,$withDefaults,$pruneKeepDefaultValue,$sourceText,$plugin) {
+        $default_rows_for_sets = "attribute_set_name,attribute_code,attribute_group_name
+*,name,General
+*,description,General
+*,short_description,General
+*,sku,General
+*,weight,General
+*,news_from_date,General
+*,news_to_date,General
+*,status,General
+*,url_key,General
+*,visibility,General
+*,country_of_manufacture,General
+*,price,Prices
+*,group_price,Prices
+*,special_price,Prices
+*,special_from_date,Prices
+*,special_to_date,Prices
+*,tier_price,Prices
+*,msrp_enabled,Prices
+*,msrp_display_actual_price_type,Prices
+*,msrp,Prices
+*,tax_class_id,Prices
+*,price_view,Prices
+*,meta_title,Meta Information
+*,meta_keyword,Meta Information
+*,meta_description,Meta Information
+*,image,Images
+*,small_image,Images
+*,thumbnail,Images
+*,media_gallery,Images
+*,gallery,Images
+*,is_recurring,Recurring Profile
+*,recurring_profile,Recurring Profile
+*,custom_design,Design
+*,custom_design_from,Design
+*,custom_design_to,Design
+*,custom_layout_update,Design
+*,page_layout,Design
+*,options_container,Design
+*,gift_message_available,Gift Options";
+        
+        
+        if(isset($title)) {
+            ?><h3><?php echo $title ?></h3><?php
+        }
+        if($withEnable) {
+            checkbox($self,$prefix,'enable',true,"Enable ${entityName} import");
+            startDiv($self,$prefix,'enabled',$self->getParam($prefix.":enable","off")=="on");
+        }
+        if($withCsvOptions)
+            csvOptions($self,$prefix);
+        ?>
+        <h4>Import behavior</h4>
+        <?php
+        if($withDefaults)
+            text($self,$prefix,'default_values',"","Set default values for non-existing columns in $sourceText (JSON)");
+        if($prefix == '5B5AAI') {
+            textarea($self,$prefix,'default_rows',$default_rows_for_sets,"Add these attribute associations to given CSV data, '*' for attribute set name  means 'for each attribute set from given CSV' (Format: CSV with titles, spearator ',', enclosure '\"').");
+        }
+        checkbox($self,$prefix,'prune',true,"Prune ${entityName}s which are not in $sourceText from database");
+        startDiv($self,$prefix,'prune_opts');
+        if($prefix == '5B5ATI' || $prefix == '5B5AAI')
+            checkbox($self,$prefix,'prune_keep_system_attributes',true,"Dont touch non-user attributes when pruning.");
+        text($self,$prefix,'prune_keep',$pruneKeepDefaultValue,"additionally, keep following ${entityName}s when pruning, even if not given in $sourceText (comma-separated)");
+        endDiv($self);
+        if($withMagmiDelete)
+            checkbox($self,$prefix,'magmi_delete',true,"Delete ${entityName}s marked \"magmi:delete\" = 1");
+        checkbox($self,$prefix,'create',true,"Create ${entityName}s from $sourceText which are not in database");
+        checkbox($self,$prefix,'update',true,"Update ${entityName}s from $sourceText which are already in database");
+        if($prefix == '5B5ASI') {
+            startDiv($self,$prefix,'attribute_groups');
+            options($self,null,'5B5AGI','attribute group',false,false,false,false,"General,Prices,Meta Information,Images,Recurring Profile,Design,Gift Options",'"magmi:groups"',$plugin);
+            endDiv($self);
+        }
+        if($withEnable)
+            endDiv($self);
+        javascript($self,$prefix,$withCsvOptions,$plugin);
+    }
+        
+    ?>
+<div class="plugin_description">
+	This plugin imports (inserts, updates, deletes) a list of attribute sets before the products will be updated.
+</div>
+<?php
+    options($this,'Attribute import options','5B5ATI','attribute',true,true,true,true,'category_ids,country_of_manufacture,created_at,custom_design,custom_design_from,custom_design_to,custom_layout_update,description,gallery,gift_message_available,group_price,has_options,image,image_label,is_recurring,links_exist,links_purchased_separately,links_title,media_gallery,meta_description,meta_keyword,meta_title,minimal_price,msrp,msrp_display_actual_price_type,msrp_enabled,name,news_from_date,news_to_date,old_id,options_container,page_layout,price,price_type,price_view,recurring_profile,required_options,samples_title,shipment_type,short_description,sku,sku_type,small_image,small_image_label,special_from_date,special_price,special_to_date,status,tax_class_id,thumbnail,thumbnail_label,tier_price,updated_at,url_key,url_path,visibility,weight,weight_type','CSV',$this->_plugin);
+    options($this,'Attribute set import options','5B5ASI','attribute set',true,true,true,true,'Default','CSV',$this->_plugin);
+    options($this,'Attribute association import options','5B5AAI','attribute association',true,true,true,true,'Default','CSV',$this->_plugin);
+?>

--- a/magmi/plugins/5b5/general/attributesetimport/text.php
+++ b/magmi/plugins/5b5/general/attributesetimport/text.php
@@ -1,0 +1,8 @@
+<?php
+    $fullName = "$prefix:$name";
+?>
+<div class="" id="<?php echo $fullName ?>">
+	<span class=""><?php echo $description ?>:</span><input type="text"
+		style="width: 900px;" name="<?php echo $fullName ?>"
+		value="<?php echo htmlentities($self->getParam($fullName,$default))?>"></input>
+</div>

--- a/magmi/plugins/5b5/general/attributesetimport/textarea.php
+++ b/magmi/plugins/5b5/general/attributesetimport/textarea.php
@@ -1,0 +1,7 @@
+<?php
+    $fullName = "$prefix:$name";
+?>
+<div class="" id="<?php echo $fullName ?>">
+	<span class=""><?php echo $description ?>:</span><textarea 
+		style="width: 900px;" rows=10 name="<?php echo $fullName ?>"><?php echo htmlentities($self->getParam($fullName,$default))?></textarea>
+</div>


### PR DESCRIPTION
Added a new general plugin that imports attribute, attribute set and set-to-attribute associations from different CSV files while "startup" phase of import.
There is a mediawiki notation file within the plugin dir (magmi/plugins/5b5/general/attributesetimport/attributesetimport.mediawiki) which you could use as documentation page for the plugin.