### PR TITLE
Allow update of attribute sets on products

### DIFF
--- a/magmi/inc/dbhelper.class.php
+++ b/magmi/inc/dbhelper.class.php
@@ -279,7 +279,7 @@ class DBHelper
      */
     public function delete($sql, $params = null)
     {
-        $this->exec_stmt($sql, $params);
+        return $this->exec_stmt($sql, $params)->rowCount();
     }
 
     /**
@@ -292,7 +292,7 @@ class DBHelper
      */
     public function update($sql, $params = null)
     {
-        $this->exec_stmt($sql, $params);
+        return $this->exec_stmt($sql, $params)->rowCount();
     }
 
     /**

--- a/magmi/integration/inc/attributeset_datapump.php
+++ b/magmi/integration/inc/attributeset_datapump.php
@@ -26,5 +26,9 @@ class Magmi_AttributeSet_DataPump extends Magmi_ProductImport_DataPump {
         $this->_engine->callPlugins("general", "importAttributeAssociations", $reader);
     }
 
+    public function cleanupAttributes() 
+    {
+        $this->_engine->callPlugins("general","deleteUnreferencedAttributes");
+    }
 }
 ?>

--- a/magmi/plugins/5b5/general/atrributescleanup/attributescleanup.mediawiki
+++ b/magmi/plugins/5b5/general/atrributescleanup/attributescleanup.mediawiki
@@ -1,0 +1,48 @@
+== What it does ==
+This plugin removes unreferenced attributes from products. This is useful if you're<br/>
+a) changing the attribute set of one or more products while product import
+b) updating attribute associations within existing attribute sets (e.g. with Attribute set importer).
+
+=== Where do 'unreferenced' attributes come from? ===
+''Example 1:''
+If you're changing the attribute set of a product and the new attribute set doesn't contain some attributes the old one contained, the values for the old attributes will still be in the database (and because they don't fit to the products' current attribute set might cause some problems).
+
+''Example 2:''
+It you're removing attribute-to-set associations (with Attribute set importer), but not remove the attributes itself, the products using the respective attribute set might also have some values for attributes which are no longer in the attribute set.
+
+This plugin removes all attribute values from all products, which are not in the products' current attribute set after the product import is finished.
+
+''This means, you normally will not need to use this plugin, if you don't ever change the attribute set of an existing product and you're not using the Attribute set importer plugin.''
+
+== Datapump functionality ==
+The datapump functionality is included in the datapump extension provided by the attribute set import plugin.
+ $dp=Magmi_DataPumpFactory::getDataPumpInstance("attributesetimport");
+ 
+You can call the cleanup functionality by calling the function
+ cleanupAttributes();
+
+The used import profile must have the Attributes Cleanup Plugin configured!
+
+Example (based on default DataPump example):
+ <?php
+ // assuming that your script file is located in magmi/integration/scripts/somedirectory/myscript.php,
+ // include "magmi_defs.php" , once done, you will be able to use any magmi includes without specific path.
+ require_once("../../../inc/magmi_defs.php");
+ //Datapump include
+ require_once("magmi_datapump.php");
+ 
+ // Difference to "normal" datapump!!! Create an Attribute Set import Datapump using Magmi_DatapumpFactory
+ $dp=Magmi_DataPumpFactory::getDataPumpInstance("attributesetimport");
+ 
+ // Begin import session with a profile & running mode, here profile is "default" & running mode is "create".
+ // Available modes: "create" creates and updates items, "update" updates only, "xcreate creates only.
+ // Important: for values other than "default" profile has to be an existing magmi profile (profile must have cleanup plugin configured!)
+ $dp->beginImportSession("default","create");
+ 
+ // perform cleanup
+ // Now ingest item(s) into magento
+ $dp->cleanupAttributes();
+ 
+ // End import Session
+ $dp->endImportSession();
+ ?>

--- a/magmi/plugins/5b5/general/atrributescleanup/attributescleanup.php
+++ b/magmi/plugins/5b5/general/atrributescleanup/attributescleanup.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * Attributes Cleanup.
+ * 
+ * Removes attributes for products, which are not in the prodoct's attribute set.
+ * This is particularly useful if
+ * a) updating products with different attribute sets (which normally results in "old" attributes from old set still in set) or
+ * b) changing attribute sets e.g with Attribute Set Importer Plugin.
+ *
+ * @author 5byfive GmbH (T.Rosenstiel) based on code (Magmi framework) by Dweeves
+ * 
+ * Copyright (C) 2015 by 5byfive GmbH (T. Rosenstiel) and Dweeves (S.BRACQUEMONT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+class AttributeCleanup extends Magmi_GeneralImportPlugin
+{
+    public function initialize($params)
+    {
+    }
+
+    public function getPluginInfo()
+    {
+        return array("name"=>"Attribute Cleanup","author"=>"5byfive GmbH","version"=>"0.0.1","url"=>$this->pluginDocUrl("Attribute_cleanup"));
+    }
+
+    public function beforeImport()
+    {
+        // intentionally left blank...
+    }
+    
+
+    public function afterImport()
+    {
+        $this->deleteUnreferencedAttributes();
+    }
+    
+
+    public function deleteUnreferencedAttributes() {
+        $this->log('Will delete unreferenced attribute values.','startup');
+        $tables = array(
+        //                 'catalog_category_entity_datetime'
+        //                 ,'catalog_category_entity_decimal'
+        //                 ,'catalog_category_entity_int'
+        //                 ,'catalog_category_entity_text'
+        //                 ,'catalog_category_entity_varchar',
+                'catalog_product_entity_datetime'
+                ,'catalog_product_entity_decimal'
+                ,'catalog_product_entity_gallery'
+                ,'catalog_product_entity_int'
+                ,'catalog_product_entity_text'
+                ,'catalog_product_entity_varchar'
+                //                 ,'customer_address_entity_datetime'
+        //                 ,'customer_address_entity_decimal'
+        //                 ,'customer_address_entity_int'
+        //                 ,'customer_address_entity_text'
+        //                 ,'customer_address_entity_varchar'
+        //                 ,'customer_entity_datetime'
+        //                 ,'customer_entity_decimal'
+        //                 ,'customer_entity_int'
+        //                 ,'customer_entity_text'
+        //                 ,'customer_entity_varchar'
+                ,'eav_entity_datetime'
+                ,'eav_entity_decimal'
+                ,'eav_entity_int'
+                ,'eav_entity_text'
+                ,'eav_entity_varchar'
+                ,'weee_tax'
+                ,'catalog_product_entity_media_gallery'
+                ,'catalog_product_index_eav'
+                ,'catalog_product_index_eav_decimal'
+                ,'catalog_product_index_eav_decimal_idx'
+                ,'catalog_product_index_eav_decimal_tmp'
+                ,'catalog_product_index_eav_idx'
+                ,'catalog_product_index_eav_tmp'
+                ,['catalog_product_super_attribute','product_id']
+        );
+
+        foreach($tables as $table) {
+            $tableEntityFieldName = "entity_id";
+            if(is_array($table)) {
+                $tableEntityFieldName = $table[1];
+                $table = $table[0];
+            }
+            $deleteSql = "
+            DELETE      ##$table##
+            FROM        ##$table##
+            INNER JOIN  ##eav_attribute## on ##eav_attribute##.attribute_id = ##$table##.attribute_id
+            INNER JOIN  ##catalog_product_entity## on ##catalog_product_entity##.entity_id = ##$table##.$tableEntityFieldName
+            LEFT OUTER JOIN ##eav_entity_attribute## on (##eav_entity_attribute##.attribute_set_id = ##catalog_product_entity##.attribute_set_id AND ##eav_entity_attribute##.attribute_id = ##$table##.attribute_id)
+            WHERE       ##eav_attribute##.entity_type_id = ?
+            AND         ##eav_attribute##.is_user_defined = 1
+            AND         ##eav_entity_attribute##.attribute_id IS NULL";
+            $sql = preg_replace_callback('/(##[a-zA-Z_]*##)/Uis',function($ms){foreach($ms as $m){return str_replace('##','',$this->tablename($m));}},$deleteSql);
+    
+            $count = $this->delete($sql,array($this->getProductEntityType()));
+            if($count > 0) {
+                $this->log("Deleted $count records from table $table.",'startup');
+            }
+        }
+        $this->log('Done deleting unreferenced attribute values.','startup');
+    }
+    
+    
+    /**
+     * Calls the engine's trace function with the plugin's name and version as a prefix.
+     * @param Exception $e the exception to trace
+     * @param string $message message
+     */
+    public function trace($e,$message="no message") {
+        $pinf = $this->getPluginInfo();
+        $data = "{$pinf["name"]} v{$pinf["version"]} - ".$message;
+        $this->_caller_trace($e,$data);
+    }
+}
+

--- a/magmi/plugins/5b5/general/atrributescleanup/options_panel.php
+++ b/magmi/plugins/5b5/general/atrributescleanup/options_panel.php
@@ -1,0 +1,3 @@
+<div class="plugin_description">
+	This plugin removes unreferenced attributes from products after product import.
+</div>

--- a/magmi/plugins/5b5/general/attributesetimport/attributesetimport.php
+++ b/magmi/plugins/5b5/general/attributesetimport/attributesetimport.php
@@ -37,12 +37,6 @@ require_once ("name2id_decoding.php");
 class AttributeSetImporter extends Magmi_GeneralImportPlugin
 {
     /**
-     * Variable storing the entity type id (dynamically fetched from database in fetchProdEType() )
-     * @var integer
-     */
-    protected $_prod_etype;
-
-    /**
      * Config parameters for call to updateGeneric when processing attributes.
      * @var array
      */
@@ -265,7 +259,7 @@ class AttributeSetImporter extends Magmi_GeneralImportPlugin
     public function importAttributes($csvreader) {
         $this->fetchProdEType();
         // condition to restrict on product entity type (will be given as default and fetchConditions to updateGeneric() function
-        $etiCondition = ['entity_type_id' => $this->_prod_etype];
+        $etiCondition = ['entity_type_id' => $this->getProductEntityType()];
         $this->updateGeneric($csvreader,$this->ATTRIBUTE_ARGS,$etiCondition,$etiCondition);
     }
 
@@ -276,7 +270,7 @@ class AttributeSetImporter extends Magmi_GeneralImportPlugin
     public function importAttributeSets($csvreader) {
         $this->fetchProdEType();
         // condition to restrict on product entity type (will be given as default and fetchConditions to updateGeneric() function
-        $etiCondition = ['entity_type_id' => $this->_prod_etype];
+        $etiCondition = ['entity_type_id' => $this->getProductEntityType()];
         $this->updateGeneric($csvreader,$this->ATTRIBUTE_SET_ARGS,$etiCondition,$etiCondition);
     }
 
@@ -286,12 +280,12 @@ class AttributeSetImporter extends Magmi_GeneralImportPlugin
     public function importAttributeAssociations($csvreader) {
         $this->fetchProdEType();
         // condition to restrict on product entity type (will be given as default and fetchConditions to updateGeneric() function
-        $etiCondition = ['entity_type_id' => $this->_prod_etype];
+        $etiCondition = ['entity_type_id' => $this->getProductEntityType()];
 
         // dynamically add product entity type id to decoder options
         $decoderArgs = array_merge_recursive($this->ATTRIBUTE_SET_ASSOCIATION_DECODER_ARGS,
-                ['attribute_set_name'=>['conditions' =>['entity_type_id' => $this->_prod_etype]],
-                        'attribute_code'=>['conditions' =>['entity_type_id' => $this->_prod_etype]]]);
+                ['attribute_set_name'=>['conditions' =>['entity_type_id' => $this->getProductEntityType()]],
+                        'attribute_code'=>['conditions' =>['entity_type_id' => $this->getProductEntityType()]]]);
 
         $decoder = new Name2IdDecoder($this,$decoderArgs);
         $this->updateGeneric($csvreader,$this->ATTRIBUTE_SET_ASSOCIATION_ARGS,$etiCondition,$etiCondition,$decoder);
@@ -856,18 +850,6 @@ class AttributeSetImporter extends Magmi_GeneralImportPlugin
     public function afterImport()
     {
         // intentionally left blank...
-    }
-
-    /**
-     * Fetches the entity_type_id from database and stores it to $this->_prod_etype
-     */
-    private function fetchProdEType()
-    {
-        if($this->_prod_etype == null) {
-            $tname = $this->tablename("eav_entity_type");
-            $this->_prod_etype = $this->selectone("SELECT entity_type_id FROM $tname WHERE entity_type_code=?",
-                    "catalog_product", "entity_type_id");
-        }
     }
 
     /**

--- a/magmi/web/magmi_config_setup.php
+++ b/magmi/web/magmi_config_setup.php
@@ -277,6 +277,24 @@ $cansock = !($dmysqlsock === false);
 				<li class="value"><input type="text" name="GLOBAL:filemask" size="3"
 					value="<?php echo $conf->get("GLOBAL","filemask","644")?>"></input></li>
 			</ul>
+			<h3>Backward compatibility</h3>
+			<ul class="formline" id="noattsetupdate">
+				<li class="label">Disable attribute set update:</li>
+				<li class="value">
+					<input type="checkbox" id="noattsetupdate_cb"
+						<?php if($conf->get("GLOBAL","noattsetupdate","off")=="on"){?>
+						checked="checked" <?php }?>>
+						<input type="hidden" id="noattsetupdate_hf" name="GLOBAL:noattsetupdate" value="<?php echo $conf->get("GLOBAL","noattsetupdate","off") ?>"/>
+						<script type="text/javascript">
+						$('noattsetupdate_cb').observe('click',function(){
+							if($('noattsetupdate_cb').checked) {
+								$('noattsetupdate_hf').value = 'on';
+							} else {
+								$('noattsetupdate_hf').value = 'off';
+							}
+						});
+					</script></li>
+			</ul>
 
 		</div>
 		<div class="clear"></div>


### PR DESCRIPTION
This change contains different changes related to the main goal of allowing to update attribute sets on products while import:
* Cleaned up fetchProdEType(), $this->_prod_etype and other methods to obtain the "catalog product" entity type into one single function "getProductEntityType()" (which was already existing before)
* Added attribute set update functionality to productimport engine.
* Added a global configuration option to disable attribute set update (to allow users to simulate old import behavior if needed)
* Added new general plugin "Attribute Cleanup", which removes attributes from products which don't belong to it's attribute set (either after attribute set of product was changed or attribute set itself was changed)