### PR TITLE
Ability to zip up email reports

### DIFF
--- a/magmi/plugins/base/general/emailreport/emailreport.php
+++ b/magmi/plugins/base/general/emailreport/emailreport.php
@@ -50,7 +50,7 @@ class EmailReportPlugin extends Magmi_GeneralImportPlugin
 		if ($archive->open($fname,ZipArchive::OVERWRITE) === true){
 		    for ($i = 0; $i < count($attachments); $i++){
 			if (!is_file($attachments[$i])) continue;
-			$fileatt_name = explode("/",$attachments[$i]);
+			$fileatt_name = explode(DIRECTORY_SEPARATOR,$attachments[$i]);
 			$fileatt_name = array_pop($fileatt_name);
 			$archive->addFile($attachments[$i],$fileatt_name);
                     }

--- a/magmi/plugins/base/general/emailreport/emailreport.php
+++ b/magmi/plugins/base/general/emailreport/emailreport.php
@@ -43,7 +43,7 @@ class EmailReportPlugin extends Magmi_GeneralImportPlugin
 
             //Should we zip them?
             $zip = $this->getParam("EMAILREP:attachcsv",false);
-
+	    $this->log("Zip: $zip", "info");	
 	    if ($zip){
                 $archive = new ZipArchive();
                 $fname = sys_get_temp_dir() . '/report.zip';

--- a/magmi/plugins/base/general/emailreport/emailreport.php
+++ b/magmi/plugins/base/general/emailreport/emailreport.php
@@ -54,7 +54,7 @@ class EmailReportPlugin extends Magmi_GeneralImportPlugin
 			$fileatt_name = array_pop($fileatt_name);
 			$archive->addFile($attachments[$i],$fileatt_name);
                     }
-                    $zip->close();
+                    $archive->close();
 
                     $fileatt = $fname;
                     $fileatt_type = "application/octet-stream";

--- a/magmi/plugins/base/general/emailreport/options_panel.php
+++ b/magmi/plugins/base/general/emailreport/options_panel.php
@@ -44,4 +44,14 @@
     ?>
 		checked="checked" <?php 
 }?>>Attach source CSV</li>
+<?php if (extension_loaded('zip')){ ?>
+        <li class="value"><input type="checkbox" name="EMAILREP:zip"
+                <?php if ($this->getParam("EMAILREP:zip")==true) {
+    ?>
+                checked="checked" <?php
+}?>>Zip attachments</li>
+<?php } else { ?>
+	<li class="value"><input type='checkbox' disabled='disabled' />The <a href='http://php.net/manual/en/book.zip.php' target='_blank'>Zip extension</a> must be installed to support compression</li>
+<?php } ?>
+
 </ul>


### PR DESCRIPTION
Hi Seb,

Noticed this feature request on SF, so thought I'd knock it together.

Allows users to request that their csv file and report are zipped (required the PHP zip extension) as part of the email report - will check for existence before allowing them to enable it, but then if enabled will send the report and csv file (if selected) in a zip archive.

Best,

Liam