### PR TITLE
Fixing scope issue with 'is_configurable' attribute setting'

### DIFF
--- a/magmi/engines/magmi_productimportengine.php
+++ b/magmi/engines/magmi_productimportengine.php
@@ -944,6 +944,9 @@ class Magmi_ProductImportEngine extends Magmi_Engine
                 //if is global then , global scope applies but if configurable, back to store view scope since
                 //it's a select
                 $scope=$attrdesc["is_global"];
+				if ($attrcode != "price" && $attrdesc["is_configurable"]==1) {
+						$scope=0;
+				}
 
                 $store_ids = $this->getItemStoreIds($item, $scope);
 

--- a/magmi/engines/magmi_productimportengine.php
+++ b/magmi/engines/magmi_productimportengine.php
@@ -944,9 +944,6 @@ class Magmi_ProductImportEngine extends Magmi_Engine
                 //if is global then , global scope applies but if configurable, back to store view scope since
                 //it's a select
                 $scope=$attrdesc["is_global"];
-                if ($attrdesc["is_configurable"]==1) {
-                    $scope=0;
-                }
 
                 $store_ids = $this->getItemStoreIds($item, $scope);
 


### PR DESCRIPTION
There's no need to check 'is_configurable' attribute. By default in Magento all attributes which can be used to create configurable products MUST be global. You can check this easily in Magento admin, when adding a new attribute - if you change scope the option "Use To Create Configurable Product" will appear/disappear. 

On the other hand, many of the predefined attributes that come with Magento installation, such as "price", for some reason have set 'is_configurable' to 1. This results in a bug where prices get updated only in a default store, but not in the store which is actually stated in the data source, as price is treated as a global attribute.

Issue is described in #265 as well.