### PR TITLE
Item Limiter: blank "Columns" field causes all datasource columns to be excluded from import

### DIFF
--- a/magmi/plugins/base/itemprocessors/importlimiter/01_importlimiter.php
+++ b/magmi/plugins/base/itemprocessors/importlimiter/01_importlimiter.php
@@ -144,7 +144,7 @@ class importlimiter extends Magmi_ItemProcessor
     {
         $this->parseRanges($this->getParam("LIMITER:ranges", ""));
         $this->parseFilters($this->getParam("LIMITER:filters", ""));
-        $this->_col_filter = explode(",", $this->getParam("LIMITER:col_filter"));
+        $this->_col_filter = array_filter(explode(",", $this->getParam("LIMITER:col_filter")));
         return true;
     }
 


### PR DESCRIPTION
If the Import Limiter plugin is enabled and the Columns field is left blank, the columns are limited to nothing.  This causes an issue where the import will not continue because the limiter excludes all of the columns.

This is caused by this in the plugin file:
`explode(",", $this->getParam("LIMITER:col_filter"));`

Since `$this->getParam("LIMITER:col_filter")` is empty, `explode()` is returning the following:

    Array
    (
        [0] => 
    )

And when the `if(count($this->_col_filter) > 0)` is being done, the value `1` is being returned for `count()` because the array has one key value which is empty.

The solution is to wrap the `explode()` with a `array_filter()` to eliminate all of the blank values.

This behavior and solution for `explode()` is noted by example on the PHP manual here: http://php.net/manual/en/function.explode.php#99830