### PR TITLE
HHVM Bugfix class Magmi_UtilityEngine could not be converted to string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea
 /magmi/state/*
 !/magmi/state/dummy.txt

--- a/magmi/inc/magmi_engine.php
+++ b/magmi/inc/magmi_engine.php
@@ -46,6 +46,11 @@ abstract class Magmi_Engine extends DbHelper
         mb_internal_encoding("UTF-8");
     }
 
+    public function __toString()
+    {
+        return 'Magmi_Engine';
+    }
+
     /**
      * Engine initialization @param params : key/value array of initialization parameters
      */


### PR DESCRIPTION
Using Magmi with HHVM is currently not possible without this fix.

Also after the fix it is still only usable if you disable authentification in security.php, because HHVM did not support PHP Basic Auth. See here: https://github.com/facebook/hhvm/issues/2560

To disable auth you need to comment out everything inside security.php, but be sure to use something like htaccess for authentification instead to keep magmi secure.

Maybe a better way for magmi would be to use an own login form and not use the one from Basic Auth.