### PR TITLE
[FIX] Authentication with PHP CGI/FPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,14 @@ Authentication
 Following previous issues with the mis-use of Magmi in an insecure way, Magmi now contains built-in authentication.
 
 Once you have provided DB details and Magmi can connect to the DB, you will need to login using a set of Magento admin credentials to use Magmi. If Magmi has not yet been configured to connect, then the username and password are both 'magmi'
+
+Authentication with PHP-CGI/FPM
+-------------------------------
+
+php-cgi/fpm under Apache does not pass HTTP Basic user/pass to PHP by default
+     
+Add these lines to an .htaccess file:
+
+     RewriteEngine On
+     RewriteCond %{HTTP:Authorization} ^(.+)$
+     RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]

--- a/magmi/web/.htaccess-sample-php_cgi_fpm
+++ b/magmi/web/.htaccess-sample-php_cgi_fpm
@@ -1,0 +1,9 @@
+### php-cgi/fpm under Apache does not pass HTTP Basic user/pass to PHP by default
+
+<IfModule mod_rewrite.c>
+
+RewriteEngine on
+RewriteCond %{HTTP:Authorization} ^(.+)$
+RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+
+</IfModule>

--- a/magmi/web/security.php
+++ b/magmi/web/security.php
@@ -8,6 +8,35 @@ function authenticate($username="",$password=""){
 }
 
 if (!isset($_SERVER['PHP_AUTH_USER'])) {
+    /*
+     * php-cgi/fpm under Apache does not pass HTTP Basic user/pass to PHP by default
+     * For this workaround to work, add these lines to your .htaccess file:
+     * RewriteEngine On
+     * RewriteCond %{HTTP:Authorization} ^(.+)$
+     * RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+     * @see https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpFoundation/ServerBag.php#L47
+     */
+    $authorizationHeader = null;
+    if (isset($_SERVER['HTTP_AUTHORIZATION'])) {
+        $authorizationHeader = $_SERVER['HTTP_AUTHORIZATION'];
+    } elseif (isset($_SERVER['REDIRECT_HTTP_AUTHORIZATION'])) {
+        $authorizationHeader = $_SERVER['REDIRECT_HTTP_AUTHORIZATION'];
+    }
+    if (null !== $authorizationHeader) {
+        if (0 === stripos($authorizationHeader, 'basic ')) {
+            // Decode AUTHORIZATION header into PHP_AUTH_USER and PHP_AUTH_PW when authorization header is basic
+            $exploded = explode(':', base64_decode(substr($authorizationHeader, 6)), 2);
+            if (count($exploded) == 2) {
+                list($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']) = $exploded;
+            }
+        } elseif (empty($_SERVER['PHP_AUTH_DIGEST']) && (0 === stripos($authorizationHeader, 'digest '))) {
+            // In some circumstances PHP_AUTH_DIGEST needs to be set
+            $_SERVER['PHP_AUTH_DIGEST'] = $authorizationHeader;
+        }
+    }
+}
+
+if (!isset($_SERVER['PHP_AUTH_USER'])) {
     header('WWW-Authenticate:Basic realm="Magmi"');
     header('HTTP/1.0 401 Unauthorized');
     echo 'You must be logged in to use Magmi';


### PR DESCRIPTION
HTTP Authentication with PHP CGI/FPM is not working, since $_SERVER['PHP_AUTH_USER'] and $_SERVER['PHP_AUTH_PW'] is not set.

Workaround inspired by the Symphony code: https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpFoundation/ServerBag.php#L47