### PR TITLE
Exclude Fatal error

### DIFF
--- a/magmi/engines/magmi_productimportengine.php
+++ b/magmi/engines/magmi_productimportengine.php
@@ -1622,8 +1622,11 @@ class Magmi_ProductImportEngine extends Magmi_Engine
     {
         $t0 = microtime(true);
         $this->log("Performing Datasource Lookup...", "startup");
+        $count = 0;
 
-        $count = $this->datasource->getRecordsCount();
+        if (is_object($this->datasource))
+            $count = $this->datasource->getRecordsCount();
+
         $t1 = microtime(true);
         $time = $t1 - $t0;
         $this->log("$count:$time", "lookup");


### PR DESCRIPTION
```
$ php magmi/cli/magmi.cli.php                                                                                                                                                                                                               on  master↑2|✚2?

Fatal error: Call to a member function getRecordsCount() on null in gmagmi-git/magmi/engines/magmi_productimportengine.php on line 1626

Call Stack:
    0.0002     264920   1. {main}() gmagmi-git/magmi/cli/magmi.cli.php:0
    0.0058    1408584   2. Magmi_Engine->run() gmagmi-git/magmi/cli/magmi.cli.php:123
    0.0064    1428336   3. Magmi_ProductImportEngine->engineRun() gmagmi-git/magmi/inc/magmi_engine.php:453
    0.0178    3208496   4. Magmi_ProductImportEngine->lookup() gmagmi-git/magmi/engines/magmi_productimportengine.php:1843
```