### PR TITLE
Update attributesetimport.php

### DIFF
--- a/magmi/plugins/5b5/general/attributesetimport/attributesetimport.php
+++ b/magmi/plugins/5b5/general/attributesetimport/attributesetimport.php
@@ -238,7 +238,7 @@ class AttributeSetImporter extends Magmi_GeneralImportPlugin
             $url = $this->getParam($prefix.":remoteurl", "");
             $outname = $this->getRemoteFile($prefix, $url);
             $this->setParam($prefix.":filename", $outname);
-            $csvreader->initialize($this->_params);
+            $csvreader->initialize($this->_params, $prefix);
         }
         $csvreader->checkCSV();
 


### PR DESCRIPTION
without "$prefix" param, it fails in Line: 243 as $csvreader can not find the correct "filename" param