### PR TITLE
Encode more chars to prevent invalid config keys

### DIFF
--- a/magmi/web/js/magmi_utils.js
+++ b/magmi/web/js/magmi_utils.js
@@ -1,3 +1,7 @@
+var rawurlencode=function(str) {
+    str = (str+'').toString();        
+    return encodeURIComponent(str).replace(/!/g, '%21').replace(/'/g, '%27').replace(/\(/g, '%28').replace(/\)/g, '%29').replace(/\*/g, '%2A');
+}
 var magmi_multifield=function(listfield,dyncontainer,linetpl,vlist)
 {
 	this.vlist=vlist;
@@ -7,7 +11,7 @@ var magmi_multifield=function(listfield,dyncontainer,linetpl,vlist)
 
 	this.getinputline=function(fieldname,dvalue,linetpl)
 	{
-		linetpl=linetpl.replace('{fieldname}',fieldname).replace('{value}',dvalue).replace('{fieldname.enc}',encodeURIComponent(fieldname));
+		linetpl=linetpl.replace('{fieldname}',fieldname).replace('{value}',dvalue).replace('{fieldname.enc}',rawurlencode(fieldname));
 
 		return linetpl;
 	};


### PR DESCRIPTION
Parentheses in column mapper column names were getting saved into config keys without encoding and generating errors in parse_ini_file when the config file was subsequently loaded.