### PR TITLE
Enable options correctly on initial activation of attribute(set)importer plugin

### DIFF
--- a/magmi/plugins/5b5/general/attributesetimport/functions.php
+++ b/magmi/plugins/5b5/general/attributesetimport/functions.php
@@ -89,7 +89,7 @@ function options($self, $title, $prefix, $entityName, $withCsvOptions, $withMagm
     }
     if ($withEnable) {
         checkbox($self, $prefix, 'enable', true, "Enable ${entityName} import");
-        startDiv($self, $prefix, 'enabled', $self->getParam($prefix.":enable", "off")=="on");
+        startDiv($self, $prefix, 'enabled', $self->getParam($prefix.":enable", "on")=="on");
     }
     if ($withCsvOptions) {
         csvOptions($self, $prefix);


### PR DESCRIPTION
Change default display style of main &lt;div&gt; elements in options panel to "on" to prevent wrong presentation after initial activation of
plugin.