### PR TITLE
Fix for NOT LOGGED IN group name in grouppriceprocessor

### DIFF
--- a/magmi/plugins/extra/itemprocessors/groupprice/grouppriceprocessor.php
+++ b/magmi/plugins/extra/itemprocessors/groupprice/grouppriceprocessor.php
@@ -111,7 +111,13 @@ class grouppriceprocessor extends Magmi_ItemProcessor
                 if ($id = $this->selectone($sql, strtoupper($groupname), "customer_group_id")) {
                     $this->_groups[$col] = array('name'=>$groupname,'id'=>$id);
                 } else {
-                    $this->_groups[$col] = array('name'=>$groupname,'id'=>$this->createGroup($groupname));
+                    if($groupname == 'NOT LOGGED IN'){
+                        $this->_groups[$col] = array('name'=>$groupname,'id'=>$id);
+                    }
+                    else{
+                        $this->_groups[$col] =
+                            array('name'=>$groupname,'id'=>$this->createGroup($groupname));
+                    }
                 }
             }
         }


### PR DESCRIPTION
This is a priority bug fix if possible. Referencing #199.