### PR TITLE
Bugfix in configurable item processor plugin

### DIFF
--- a/magmi/plugins/base/itemprocessors/configurables/magmi_configurableprocessor.php
+++ b/magmi/plugins/base/itemprocessors/configurables/magmi_configurableprocessor.php
@@ -329,9 +329,9 @@ class Magmi_ConfigurableItemProcessor extends Magmi_ItemProcessor
             $this->_use_defaultopc = true;
             $this->log("no options_container set, defaulting to :Block after product info", "startup");
         }
-		  else {
+        else {
             $this->_use_defaultopc = false;
-		  }
+        }
     }
 
     public function getPluginParamNames()

--- a/magmi/plugins/base/itemprocessors/configurables/magmi_configurableprocessor.php
+++ b/magmi/plugins/base/itemprocessors/configurables/magmi_configurableprocessor.php
@@ -329,6 +329,9 @@ class Magmi_ConfigurableItemProcessor extends Magmi_ItemProcessor
             $this->_use_defaultopc = true;
             $this->log("no options_container set, defaulting to :Block after product info", "startup");
         }
+		  else {
+            $this->_use_defaultopc = false;
+		  }
     }
 
     public function getPluginParamNames()


### PR DESCRIPTION
Fixed Configurable plugin bug when mixed products are imported (configurable and simple) in the "options_container".