### PR TITLE
First image can be excluded during magmi re-import with no reason. 

### DIFF
--- a/magmi/engines/magmi_productimportengine.php
+++ b/magmi/engines/magmi_productimportengine.php
@@ -384,7 +384,7 @@ class Magmi_ProductImportEngine extends Magmi_Engine
                 // SQL for selecting attribute properties for all wanted attributes
                 $sql = "SELECT `$tname`.*,$extra.* FROM `$tname`
                         LEFT JOIN $extra ON $tname.attribute_id=$extra.attribute_id
-                        WHERE  ($tname.attribute_code IN ($qcolstr)) AND (entity_type_id=?)";
+                        WHERE  ($tname.attribute_code IN ($qcolstr)) AND (entity_type_id=?) ORDER BY $tname.attribute_id";
             } else {
                 $sql = "SELECT `$tname`.* FROM `$tname` WHERE ($tname.attribute_code IN ($qcolstr)) AND (entity_type_id=?)";
             }


### PR DESCRIPTION
When using image items processor, first image is excluded for each products during product re-import (excluded flag is checked). 

Visibly, image processor is waiting for fields in their attribute_id order (i. e. images fields before gallery field).
Patch is to make sure it is always the case.

Explanation :
It happens only when UNQ_EAV_ATTRIBUTE_ENTITY_TYPE_ID_ATTRIBUTE_CODE is used by MySql as key to query eav_attribute database in request.

Database KO (before patch): 
This can be traced to : 
With Mysql EXPLAIN, we have : 
| id | select_type | table                 | type   | possible_keys                                                                    | key                                             | key_len | ref                                    | rows | Extra       |
+----+-------------+-----------------------+--------+----------------------------------------------------------------------------------+-------------------------------------------------+---------+----------------------------------------+------+-------------+
|  1 | SIMPLE      | eav_attribute         | ref    | UNQ_EAV_ATTRIBUTE_ENTITY_TYPE_ID_ATTRIBUTE_CODE,IDX_EAV_ATTRIBUTE_ENTITY_TYPE_ID | UNQ_EAV_ATTRIBUTE_ENTITY_TYPE_ID_ATTRIBUTE_CODE | 2       | const                                  |   89 | Using where |
|  1 | SIMPLE      | catalog_eav_attribute | eq_ref | PRIMARY                                                                          | PRIMARY                                         | 2       | clemoptimal.eav_attribute.attribute_id |    1 |             |
+----+-------------+-----------------------+--------+----------------------------------------------------------------------------------+-------------------------------------------------+---------+----------------------------------------+------+-------------+ 
UNQ_EAV_ATTRIBUTE_ENTITY_TYPE_ID_ATTRIBUTE_CODE is used as key for catalog_eav_attribute
first image is excluded for each products during product re-import (excluded flag is checked when it should not be checked). 

Database OK (before patch). With Mysql EXPLAIN, we have :
| id | select_type | table                 | type   | possible_keys                                                                    | key                              | key_len | ref                                   | rows | Extra       |
+----+-------------+-----------------------+--------+----------------------------------------------------------------------------------+----------------------------------+---------+---------------------------------------+------+-------------+
|  1 | SIMPLE      | eav_attribute         | ref    | UNQ_EAV_ATTRIBUTE_ENTITY_TYPE_ID_ATTRIBUTE_CODE,IDX_EAV_ATTRIBUTE_ENTITY_TYPE_ID | IDX_EAV_ATTRIBUTE_ENTITY_TYPE_ID | 2       | const                                 |   74 | Using where |
|  1 | SIMPLE      | catalog_eav_attribute | eq_ref | PRIMARY                                                                          | PRIMARY                          | 2       | clembourse.eav_attribute.attribute_id |    1 |             |

IDX_EAV_ATTRIBUTE_ENTITY_TYPE_ID is used as key for catalog_eav_attribute. Exclude flag is not checked when it should not be checked.



