### PR TITLE
Allow position update to change attribute ordering after creation

### DIFF
--- a/magmi/plugins/base/itemprocessors/configurables/magmi_configurableprocessor.php
+++ b/magmi/plugins/base/itemprocessors/configurables/magmi_configurableprocessor.php
@@ -221,6 +221,10 @@ class Magmi_ConfigurableItemProcessor extends Magmi_ItemProcessor
                 $psaid = $this->insert($sql, array($pid, $attrid, $idx));
             }
 
+            // Allow position update to update attribute ordering
+            $sql = "UPDATE `$cpsa` SET position=? WHERE product_super_attribute_id=?";
+            $this->update($sql, array($idx, $psaid));
+
             // for all stores defined for the item
             $sids = $this->getItemStoreIds($item, 0);
             $data = array();


### PR DESCRIPTION
I had to update the ordering of configurable attributes after initial creation, so I added the ability. Hope this a valid request, as I haven't added anything previously to MAGMI.

BTW: Thanks for MAGMI! It's a really great tool and easy to extend.