### PR TITLE
Fix for duplicate images that would cause multiple realtions...

### DIFF
--- a/magmi/plugins/extra/itemprocessors/imageprocessor/imageitattributeemprocessor.php
+++ b/magmi/plugins/extra/itemprocessors/imageprocessor/imageitattributeemprocessor.php
@@ -224,12 +224,15 @@ class ImageAttributeItemProcessor extends Magmi_ItemProcessor
     }
 
     /**
-     * imageInGallery
+     * Creates or updates image and returns its id.
      *
      * @param int $pid
      *            : product id to test image existence in gallery
      * @param string $imgname
      *            : image file name (relative to /products/media in magento dir)
+     * @param int $refid
+     *            : A reference to an attribute type, typically of image,
+     *            small_image or thumbnail
      * @return bool : if image is already present in gallery for a given product id
      */
     public function getImageId($pid, $attid, $imgname, $refid = null, $store_id = 0)
@@ -237,16 +240,22 @@ class ImageAttributeItemProcessor extends Magmi_ItemProcessor
         $t = $this->tablename('catalog_product_entity_media_gallery');
 
         $sql = "SELECT $t.value_id FROM $t ";
+
+        // Try finding matching refid
         if ($refid != null) {
             $vc = $this->tablename('catalog_product_entity_varchar');
-            $sql .= " JOIN $vc ON $t.entity_id=$vc.entity_id AND $t.value=$vc.value AND $vc.attribute_id=?
+            $full_sql = $sql . " JOIN $vc ON $t.entity_id=$vc.entity_id AND $t.value=$vc.value AND $vc.attribute_id=?
 					WHERE $t.entity_id=? AND $vc.store_id=?";
-            $imgid = $this->selectone($sql, array($refid, $pid, $store_id), 'value_id');
-        } else {
-            $sql .= " WHERE value=? AND entity_id=? AND attribute_id=?";
-            $imgid = $this->selectone($sql, array($imgname, $pid, $attid), 'value_id');
+            $imgid = $this->selectone($full_sql, array($refid, $pid, $store_id), 'value_id');
         }
 
+        // If not found just match on type and value
+        if ($imgid == null) {
+            $full_sql = $sql . " WHERE value=? AND entity_id=? AND attribute_id=?";
+            $imgid = $this->selectone($full_sql, array($imgname, $pid, $attid), 'value_id');
+        }
+
+        // If still not found, create it
         if ($imgid == null) {
             // insert image in media_gallery
             $sql = "INSERT INTO $t


### PR DESCRIPTION
... to the same image on the same product.

Solves one part of https://github.com/dweeves/magmi-git/issues/471 which is about image 'exclude' flags not being set correctly. As it turns out the problem was a combination between duplicate images by magmi and evil Magento that would clean up the table/relations as soon as you'd view the product in adminhtml.

