### PR TITLE
Fix Advanced Utilities for Group Price

### DIFF
--- a/magmi/plugins/utilities/clearproducts/clearproduct.php
+++ b/magmi/plugins/utilities/clearproducts/clearproduct.php
@@ -21,6 +21,7 @@ class ClearProductUtility extends Magmi_UtilityPlugin
             "catalog_product_super_attribute_label","catalog_product_super_attribute_pricing",
             "catalog_product_super_attribute","catalog_product_super_link","catalog_product_link",
             "catalog_product_link_attribute_varchar","catalog_product_link_attribute_int",
+            "catalog_product_entity_group_price",
 
             "catalog_product_relation","catalog_product_enabled_index","catalog_product_website",
             "catalog_category_product_index","catalog_category_product","cataloginventory_stock_item",

--- a/magmi/plugins/utilities/clearproductsandcategories/clearproductsandcategories.php
+++ b/magmi/plugins/utilities/clearproductsandcategories/clearproductsandcategories.php
@@ -18,6 +18,7 @@ class ClearProductandcategoryUtility extends Magmi_UtilityPlugin
             "catalog_product_entity_tier_price","catalog_product_entity_varchar","catalog_product_link",
             "catalog_product_link_attribute_decimal","catalog_product_link_attribute_int",
             "catalog_product_link_attribute_varchar",
+            "catalog_product_entity_group_price",
 
             // "catalog_product_link_attribute",
             // "catalog_product_link_type",


### PR DESCRIPTION
Add truncate for **catalog_product_entity_group_price** table in "Clear Customers, Tags and Wishlists" and "Clear Catalog, Categories and Reviews" utilities.
If you have product with group price and use clean catalog after that you can not reindex.