### PR TITLE
Added checking is property not empty string

### DIFF
--- a/magmi/inc/properties.php
+++ b/magmi/inc/properties.php
@@ -183,7 +183,9 @@ class Properties
      */
     public function get($secname, $pname, $default = null)
     {
-        if (isset($this->_props[$secname]) && isset($this->_props[$secname][$pname]))
+        if (isset($this->_props[$secname])
+            && isset($this->_props[$secname][$pname])
+            && $this->_props[$secname][$pname] != '')
         {
             $v = $this->_props[$secname][$pname];
             return $v;


### PR DESCRIPTION
This change fixes null return when property is empty string. 
When property was empty default value has never been returned.