### PR TITLE
Fix category product position

### DIFF
--- a/magmi/plugins/extra/itemprocessors/categories/categoryimport.php
+++ b/magmi/plugins/extra/itemprocessors/categories/categoryimport.php
@@ -304,6 +304,8 @@ class CategoryImporter extends Magmi_ItemProcessor
                 } else {
                     $catpos[] = "0";
                 }
+            } else {
+                $catpos[] = "0";       
             }
             $translation_option = array_values(array_filter($a, function ($option) { return stripos($option, '[') === 0; }));
             $translation_option_part = count($translation_option) ? '::' . $translation_option[0] : '';


### PR DESCRIPTION
Fix category product position when base category tree is setted on plugin configuration o some category not have `::x::x::x`
If Base category or some category not have `::x::x::x` set array `$catpos` is not in sync with `$catids` array (see line 375) and category position not working correctly.

Resolve #512 
