### PR TITLE
null equality issue

### DIFF
--- a/magmi/engines/magmi_productimportengine.php
+++ b/magmi/engines/magmi_productimportengine.php
@@ -1678,7 +1678,7 @@ class Magmi_ProductImportEngine extends Magmi_Engine
                         }
                     }
                     // if we have something to do with this value
-                    if ($ovalue !== false && $ovalue != null)
+                    if ($ovalue !== false && $ovalue !== null)
                     {
                         $data[] = $this->getProductEntityType();
                         $data[] = $attid;


### PR DESCRIPTION
if ($ovalue !== false && $ovalue != null) returns wrong result in php 5.6.30 and sets $ovalue as false