### PR TITLE
Allow for value translation with select/multiselect attributes when is_configurable=0 and scope is global

### DIFF
--- a/magmi/engines/magmi_productimportengine.php
+++ b/magmi/engines/magmi_productimportengine.php
@@ -1619,10 +1619,10 @@ class Magmi_ProductImportEngine extends Magmi_Engine
                 // get the item value
                 $ivalue = $item[$attrcode];
                 // get item store id for the current attribute
-                //if is global then , global scope applies but if configurable, back to store view scope since
-                //it's a select
+                // if the attribute is global, then global scope applies. However, for select & multiselect 
+                // attributes, we go back to the store view scope to allow for values translation
                 $scope = $attrdesc["is_global"];
-                if ($attrcode != "price" && $attrdesc["is_configurable"] == 1)
+                if ($attrcode != "price" && $attrdesc["is_global"] && ($attrdesc["frontend_input"] == 'select' || $attrdesc["frontend_input"] == 'multiselect'))
                 {
                     $scope = 0;
                 }


### PR DESCRIPTION
Hi Dweeves,

I need to be able to translate values for select attributes which are "global" **but are not set to be configurable attributes**. That's not possible at the moment based on the current logic.

I've read what you've said on #358 about why you choose to force store scope for configurable attributes, but I think you've got to do it not only for configurable attributes but for all select/multiselect attributes in the global scope.

I've made the change and it works. Please have a look when you've got time.

Cheers