### PR TITLE
Fix issue when report step is empty and cause "DivisionByZeroError"

### DIFF
--- a/magmi/engines/magmi_productimportengine.php
+++ b/magmi/engines/magmi_productimportengine.php
@@ -1130,10 +1130,14 @@ class Magmi_ProductImportEngine extends Magmi_Engine
         $res = array("ok" => 0, "last" => 0);
         $canceled = false;
         $this->_current_row++;
-        if ($this->_current_row % $rstep == 0)
-        {
-            $this->reportStats($this->_current_row, $tstart, $tdiff, $lastdbtime, $lastrec);
+
+        if ($rstep > 0) {
+            if ($this->_current_row % $rstep == 0)
+            {
+                $this->reportStats($this->_current_row, $tstart, $tdiff, $lastdbtime, $lastrec);
+            }
         }
+
         try
         {
             if (is_array($item) && count($item) > 0)


### PR DESCRIPTION
**Problem**
- When report step config is not set or empty the import process will be halted without any error message. This fix works as a protection so the import will continue to run in this case
