### PR TITLE
Obtaining the safe_mode config has incorrect closing parenthesis

### DIFF
--- a/magmi/inc/remotefilegetter.php
+++ b/magmi/inc/remotefilegetter.php
@@ -100,7 +100,9 @@ class CURL_RemoteFileGetter extends RemoteFileGetter
                 }
                 //fix for some servers not able to follow location & failing downloads
                 //only set follow location if compatible with PHP settings
-                if (ini_get('open_basedir') == '' && ini_get('safe_mode' == 'Off')) {
+                $safeMode = ini_get('safe_mode');
+                $safeModeDisabled = ($safeMode == 'Off') || !$safeMode;
+                if (ini_get('open_basedir') == '' && $safeModeDisabled) {
                     $curlopts[CURLOPT_FOLLOWLOCATION]=1;
                 }
                 break;


### PR DESCRIPTION
The condition currently has an incorrect closing parenthesis which causes the parameter to ini_get to be "false". Also with PHP7 ini_get for the "safe_mode" parameter will return a boolean rather than a string. This patch also contains a condition to handle both cases. Both these issues causes remote CSV file downloads that have redirects (i.e. Dropbox) to always fail.