### PR TITLE
Fix bundle products import issue: Field `parent_product_id` doesn not…

### DIFF
--- a/magmi/plugins/base/itemprocessors/bundle/limora_bundleprocessor.php
+++ b/magmi/plugins/base/itemprocessors/bundle/limora_bundleprocessor.php
@@ -163,9 +163,9 @@ class Magmi_BundleItemProcessor extends Magmi_ItemProcessor
 
                     if (!empty($option['title'])) {
                         if (empty($existingOption['title'])) {
-                            $sql = "INSERT INTO $optv (option_id, store_id, title) VALUES(:option_id, :store_id, :title)";
+                            $sql = "INSERT INTO $optv (option_id, store_id, title,parent_product_id) VALUES(:option_id, :store_id, :title, :parent_product_id)";
                             $bind = array('option_id'=>$option['option_id'],'store_id'=>$option['store_id'],
-                                'title'=>$option['title']);
+                                'title'=>$option['title'],'parent_product_id' => $option['parent_id']);
                             $this->insert($sql, $bind);
                         } elseif ($existingOption['title'] != $option['title']) {
                             $sql = "UPDATE $optv SET title = :title WHERE option_id = :option_id AND store_id = :store_id";
@@ -181,13 +181,13 @@ class Magmi_BundleItemProcessor extends Magmi_ItemProcessor
                     $optionId = $this->insert($sql, $bind);
                     $option['option_id'] = $optionId;
 
-                    $sql = "INSERT INTO $optv (option_id, store_id, title) VALUES(:option_id, :store_id, :title)";
-                    $bind = array('option_id'=>$option['option_id'],'store_id'=>0,'title'=>$option['code']);
+                    $sql = "INSERT INTO $optv (option_id, store_id, title, parent_product_id) VALUES(:option_id, :store_id, :title, :parent_product_id)";
+                    $bind = array('option_id'=>$option['option_id'],'store_id'=>0,'title'=>$option['code'],'parent_product_id' => $option['parent_id']);
                     $this->insert($sql, $bind);
 
                     if (!empty($option['title']) && $option['store_id'] != 0) {
                         $bind = array('option_id'=>$option['option_id'],'store_id'=>$option['store_id'],
-                            'title'=>$option['title']);
+                            'title'=>$option['title'],'parent_product_id' => $option['parent_id']);
                         $this->insert($sql, $bind);
                     }
                 }


### PR DESCRIPTION
Fix bundle products import issue: Field `parent_product_id` doesn't have a default value

![tim 20181227144055](https://user-images.githubusercontent.com/16289287/50470765-df03a280-09ec-11e9-8908-1c15960ec73b.png)

After fixed that, the bundle import function works well.

![tim 20181227153508](https://user-images.githubusercontent.com/16289287/50470795-022e5200-09ed-11e9-967f-8f9cd09a3f55.png)

---

Thanks magmi !

This is my blog : [www.abmbio.xin](https://www.abmbio.xin)
My github home: [https://github.com/tonyabm](https://github.com/tonyabm)

If you have any problem, please let me know.

