### PR TITLE
Add transaction logging and skip catalog_product_entity update config

### DIFF
--- a/magmi/inc/dbhelper.class.php
+++ b/magmi/inc/dbhelper.class.php
@@ -10,6 +10,9 @@ include_once("timecounter.php");
 
 class DBHelper
 {
+    /**
+     * @var PDO
+     */
     protected $_db;
     protected $_debug;
     protected $_laststmt;
@@ -22,6 +25,7 @@ class DBHelper
     protected $_tcats;
     protected $_tables2columns = array();
     protected $_dbname;
+    protected $_debugfile;
 
     public function __construct()
     {
@@ -476,9 +480,10 @@ class DBHelper
      */
     public function beginTransaction()
     {
-        $this->_db->beginTransaction();
+        $success = $this->_db->beginTransaction();
         $this->_intrans = true;
         //$this->logdebug("-- TRANSACTION BEGIN --");
+        return $success;
     }
 
     /**
@@ -486,9 +491,10 @@ class DBHelper
      */
     public function commitTransaction()
     {
-        $this->_db->commit();
+        $committed = $this->_db->commit();
         $this->_intrans = false;
         //$this->logdebug("-- TRANSACTION COMMIT --");
+        return $committed;
     }
 
     /**
@@ -496,11 +502,13 @@ class DBHelper
      */
     public function rollbackTransaction()
     {
+        $rolledBack = null;
         if ($this->_intrans) {
-            $this->_db->rollBack();
+            $rolledBack = $this->_db->rollBack();
             $this->_intrans = false;
            // $this->logdebug("-- TRANSACTION ROLLBACK --");
         }
+        return $rolledBack;
     }
 
     /**

--- a/magmi/inc/magmi_engine.php
+++ b/magmi/inc/magmi_engine.php
@@ -25,6 +25,10 @@ abstract class Magmi_Engine extends DbHelper
     protected $_builtinplugins = array();
     protected $_ploop_callbacks = array();
     private $_excid = 0;
+
+    /**
+     * @var null|Magmi_Logger
+     */
     public $logger = null;
     protected $_timingcats = array();
 
@@ -364,6 +368,11 @@ abstract class Magmi_Engine extends DbHelper
         return date('Y-m-d h:i:', $timeStamp) . (date('s', $timeStamp) + $microSec);
     }
 
+    /**
+     * @param $data
+     * @param string $type
+     * @param null|Magmi_Logger $logger
+     */
     public function log($data, $type = "default", $logger = null)
     {
         $usedlogger = ($logger == null ? $this->logger : $logger);


### PR DESCRIPTION
Introduce a new configuration to disable unnecessary product update.
Just set:
```
[MAGENTO]
catalog_product_entity_update = 0
```
in your magmi.ini.
This will prevent Magemi from updating  catalog_product_entity table when not needed e.g. usually magmi updates sku, entity_type_id to the same values as they were before. 

This PR also add logging when beginTransaction or rollback returns false.
This helps debugging deadlock situations