### PR TITLE
Resolve PHP 7.4 incompatibility in the truepath function

### DIFF
--- a/magmi/inc/magmi_utils.php
+++ b/magmi/inc/magmi_utils.php
@@ -94,7 +94,7 @@ function truepath($path)
 {
     $opath = $path;
     // whether $path is unix or not
-    $unipath = strlen($path) == 0 || $path{0}
+    $unipath = strlen($path) == 0 || $path[0]
     != '/';
     // attempts to detect if path is relative in which case, add cwd
     if (strpos($path, ':') === false && $unipath) {


### PR DESCRIPTION
This PR resolves a PHP 7.4 incompatibility in the `truepath` function.

The following was reported by the [PHP Compatibility Coding Standard for PHP_CodeSniffer](https://github.com/PHPCompatibility/PHPCompatibility) regarding this incompatibility:

    FILE: /path/to//magmi/inc/magmi_utils.php
    ---------------------------------------------------------------------------------------------------------------------------------------
    FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
    ---------------------------------------------------------------------------------------------------------------------------------------
    97 | WARNING | [x] Curly brace syntax for accessing array elements and string offsets has been deprecated in PHP 7.4. Found: $path{0}
    ---------------------------------------------------------------------------------------------------------------------------------------